### PR TITLE
Add Service Proxy to ConsolePlugin CRD 

### DIFF
--- a/charts/distributed-tracing-console-plugin/templates/consoleplugin.yaml
+++ b/charts/distributed-tracing-console-plugin/templates/consoleplugin.yaml
@@ -14,3 +14,12 @@ spec:
       namespace: {{ .Release.Namespace }}
       port: {{ .Values.plugin.port }}
       basePath: {{ .Values.plugin.basePath }}
+  proxy: 
+  - alias: backend
+    authorization: UserToken
+    endpoint:
+      service:
+        name: {{ template "openshift-console-plugin.name" . }}
+        namespace: {{ .Release.Namespace }}
+        port: {{ .Values.plugin.port }}
+      type: Service

--- a/hack/distributed-tracing-console-plugin-resources.yaml
+++ b/hack/distributed-tracing-console-plugin-resources.yaml
@@ -150,6 +150,15 @@ spec:
       namespace: openshift-tracing
       basePath: "/"
       port: 9443
+  proxy: 
+  - alias: backend
+    authorization: UserToken
+    endpoint:
+      service:
+        name: distributed-tracing-console-plugin
+        namespace: openshift-tracing
+        port: 9443
+      type: Service
 
 ---
 apiVersion: v1

--- a/web/src/components/PersesWrapper.tsx
+++ b/web/src/components/PersesWrapper.tsx
@@ -109,7 +109,7 @@ export const PersesWrapper = (props: SelectedTempoStackProps) => {
     return <TraceEmptyState />;
   }
 
-  const url = `/api/plugins/distributed-tracing-console-plugin/proxy/${props.selectedNamespace}/${props.selectedTempoStack}`;
+  const url = `/api/proxy/plugin/distributed-tracing-console-plugin/backend/proxy/${props.selectedNamespace}/${props.selectedTempoStack}`;
   const proxyDatasource: GlobalDatasource = {
     kind: 'GlobalDatasource',
     metadata: { name: 'TempoProxy' },


### PR DESCRIPTION
- Add Service Proxy to ConsolePlugin CRD.
- Update frontend to use Service Proxy endpoint q/api/proxy/plugin/distributed-tracing-console-plugin/backend/` for querying tempostack