### PR TITLE
Show a '<1ms' notice in the table for small trace durations

### DIFF
--- a/web/src/components/TraceTable.tsx
+++ b/web/src/components/TraceTable.tsx
@@ -86,7 +86,9 @@ export const TraceTable: React.FunctionComponent = () => {
         {traces.map((trace) => (
           <Tr key={trace.traceId}>
             <Td dataLabel={columnNames.traceId}>{trace.traceId}</Td>
-            <Td dataLabel={columnNames.durationMs}>{trace.durationMs}</Td>
+            <Td dataLabel={columnNames.durationMs}>
+              {!trace.durationMs ? '<1ms' : trace.durationMs}
+            </Td>
             <Td dataLabel={columnNames.spanCount}>{trace.spanCount}</Td>
             <Td dataLabel={columnNames.errorCount}>{trace.errorCount}</Td>
             <Td dataLabel={columnNames.startTime}>


### PR DESCRIPTION
Perses doesn't currently provide support for traces which take less than 1ms. The duration is left blank in their datastore and the spans are not left available, meaning that the duration can't be calculated from the spans either.

In order to solve this problem, upstream work on Perses is required. However, to get the distributed tracing plugin in working order for its release, we will add an additional description in the table to show that the trace took less than 1 millisecond so that users will know what the data is, even if it isn't specific enough currently.

This PR does not impact the scatterplot, which will continue to be left looking blank when these short traces happen. If desired, we could remove the graph when this happens, but until upstream work is completed that is the most we can do.