### PR TITLE
OU-459: No UI option to select time period for Traces in distributed-tracing-console plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ build-backend:
 start-backend:
 	go run ./cmd/plugin-backend.go -port='9002' -config-path='./web/dist' -static-path='./web/dist'
 
+.PHONY: start-backend-k8
+start-backend-k8:
+	./scripts/start-backend.sh
+
 .PHONY: build-image
 build-image:install
 	./scripts/build-image.sh

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -1,0 +1,24 @@
+# Objectives 
+# This allow the plugin's backend to be served from a deployed Pod. The pod is port-forwarded at localhost:9002
+# and a bridge is generated from start-console.sh.
+
+# Prerequisites
+# The distirbuted-tracing-console-plugin needs to be deployed on a cluster to use this script
+# The namespace/project match the resources found in /hack file 
+
+# Switch in to the namespace with the distributed-tracing-console-plugin
+oc project openshift-tracing 
+
+# Find the pod name (e.g. distirbuted-tracing-console-plugin-123456)
+TRACING_PLUGIN=$(oc get pods -l app=distributed-tracing-console-plugin -o jsonpath='{.items[0].metadata.name}')
+
+# Port-forward the plugin's remote port 9443 to localhost 9002 
+oc port-forward $TRACING_PLUGIN 9002:9443
+
+# Manually start the frontend server in another terminal from the root of the project 
+# $ make start-frontend 
+
+# Manually start console  
+# $ make start-console
+
+

--- a/scripts/start-console.sh
+++ b/scripts/start-console.sh
@@ -39,28 +39,27 @@ echo "npm_package_consolePlugin_name : ${npm_package_consolePlugin_name}"
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://localhost:9002"
+        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://localhost:9001"
         podman run --pull always \
         --rm --network=host \
         --env-file <(set | grep BRIDGE) \
-        --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/distributed-tracing-plugin/backend/", "endpoint":"http://localhost:9002","authorize":true}]}' \
+        --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/distributed-tracing-console-plugin/backend/", "endpoint":"http://localhost:9002","authorize":true}, {"consoleAPIPath": "/api/plugins/distributed-tracing-console-plugin/api/v1/list-tempostacks", "endpoint":"http://localhost:9002/api/v1/list-tempostacks","authorize":true}]}' \
         $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.containers.internal:9002"
+        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.containers.internal:9001"
         podman run \
         --pull always \
         --rm -p "$CONSOLE_PORT":9000 \
         --env-file <(set | grep BRIDGE)  \
-        --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/distributed-tracing-plugin/backend/", "endpoint":"http://host.containers.internal:9002","authorize":true}]}' \
+        --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/distributed-tracing-console-plugin/backend/", "endpoint":"http://host.containers.internal:9002","authorize":true}, {"consoleAPIPath": "/api/plugins/distributed-tracing-console-plugin/api/v1/list-tempostacks", "endpoint":"http://host.containers.internal:9002/api/v1/list-tempostacks","authorize":true}]}' \
         $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.docker.internal:9002"
+    BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.docker.internal:9001"
     docker run \
     --pull always \
     --rm -p "$CONSOLE_PORT":9000 \
     --env-file <(set | grep BRIDGE) \
-    --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/distributed-tracing-plugin/backend/", "endpoint":"http://host.docker.internal:9002","authorize":true}]}' \
+    --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/distributed-tracing-console-plugin/backend/", "endpoint":"https://host.docker.internal:9002","authorize":true},{"consoleAPIPath": "/api/plugins/distributed-tracing-console-plugin/api/v1/list-tempostacks", "endpoint":"https://host.docker.internal:9002/api/v1/list-tempostacks","authorize":true}]}' \
     $CONSOLE_IMAGE 
-
 fi

--- a/web/locales/en/plugin__distributed-tracing-console-plugin.json
+++ b/web/locales/en/plugin__distributed-tracing-console-plugin.json
@@ -1,9 +1,18 @@
 {
+  "Last 5 minutes": "Last 5 minutes",
+  "Last 15 minutes": "Last 15 minutes",
+  "Last 30 minutes": "Last 30 minutes",
+  "Last 1 hour": "Last 1 hour",
+  "Last 6 hours": "Last 6 hours",
+  "Last 12 hours": "Last 12 hours",
+  "Last 1 day": "Last 1 day",
+  "Last 7 days": "Last 7 days",
+  "Last 14 days": "Last 14 days",
+  "Time Range": "Time Range",
+  "Select a Time Range": "Select a Time Range",
   "Select a TempoStack": "Select a TempoStack",
   "No Tempo Stack selected": "No Tempo Stack selected",
   "Select a Tempo Stack instance to explore data": "Select a Tempo Stack instance to explore data",
   "No Data": "No Data",
-  "Loading": "Loading",
-  "Tracing": "Tracing",
-  "You have selected": "You have selected"
+  "Tracing": "Tracing"
 }

--- a/web/src/components/DurationDropdown.tsx
+++ b/web/src/components/DurationDropdown.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import {
+  Select,
+  SelectVariant,
+  SelectOption,
+  Grid,
+  GridItem,
+} from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { DurationString } from '@perses-dev/prometheus-plugin';
+
+type TimeRangeSelectOption = {
+  display: string;
+  value: DurationString;
+};
+
+type DurationDropDownProps = {
+  handleDurationChange: (timeRange: DurationString) => void;
+};
+
+export const DurationDropdown = (props: DurationDropDownProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState('30m');
+
+  const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
+
+  // The time range selection mirrors the options on the Metrics Page
+  const timeRangeSelectOptions: TimeRangeSelectOption[] = [
+    {
+      display: t('Last 5 minutes'),
+      value: '5m',
+    },
+    {
+      display: t('Last 15 minutes'),
+      value: '15m',
+    },
+    {
+      display: t('Last 30 minutes'),
+      value: '30m',
+    },
+    {
+      display: t('Last 1 hour'),
+      value: '1h',
+    },
+    {
+      display: t('Last 6 hours'),
+      value: '6h',
+    },
+    {
+      display: t('Last 12 hours'),
+      value: '12h',
+    },
+    {
+      display: t('Last 1 day'),
+      value: '1d',
+    },
+    {
+      display: t('Last 7 days'),
+      value: '7d',
+    },
+    {
+      display: t('Last 14 days'),
+      value: '14d',
+    },
+  ];
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: DurationString | undefined,
+  ) => {
+    if (!value) {
+      setSelected(undefined);
+    }
+    setSelected(value);
+    setIsOpen(false);
+    props.handleDurationChange(value);
+  };
+
+  const titleId = 'time-range-select';
+  return (
+    <Grid component="ul">
+      <GridItem component="li">
+        <label htmlFor="duration-dropdown">{t('Time Range')}</label>
+      </GridItem>
+      <GridItem component="li">
+        <Select
+          id={selected}
+          variant={SelectVariant.typeahead}
+          typeAheadAriaLabel={t('Select a Time Range')}
+          onToggle={onToggle}
+          onSelect={onSelect}
+          selections={selected}
+          isOpen={isOpen}
+          aria-labelledby={titleId}
+          placeholderText={t('Select a Time Range')}
+          width={200}
+        >
+          {timeRangeSelectOptions.map((option: TimeRangeSelectOption) => (
+            <SelectOption key={option.display} value={option.value}>
+              {option.display}
+            </SelectOption>
+          ))}
+        </Select>
+      </GridItem>
+    </Grid>
+  );
+};

--- a/web/src/components/PersesWrapper.tsx
+++ b/web/src/components/PersesWrapper.tsx
@@ -29,6 +29,7 @@ import tempoResource from '@perses-dev/tempo-plugin/plugin.json';
 import { PersesChartsTheme } from '@perses-dev/components';
 import { TraceQueryBrowser } from './TraceQueryBrowser';
 import { TraceEmptyState } from './TraceEmptyState';
+import { DurationString } from '@perses-dev/prometheus-plugin';
 
 class DatasourceApiImpl implements DatasourceApi {
   constructor(public proxyDatasource: GlobalDatasource) {}
@@ -100,6 +101,7 @@ const queryClient = new QueryClient({
 type SelectedTempoStackProps = {
   selectedNamespace: string | undefined;
   selectedTempoStack: string | undefined;
+  duration: DurationString;
 };
 
 export const PersesWrapper = (props: SelectedTempoStackProps) => {
@@ -139,7 +141,7 @@ export const PersesWrapper = (props: SelectedTempoStackProps) => {
           <QueryClientProvider client={queryClient}>
             <TimeRangeProvider
               refreshInterval="0s"
-              timeRange={{ pastDuration: '30m' }}
+              timeRange={{ pastDuration: props.duration }}
             >
               <TemplateVariableProvider>
                 <DatasourceStoreProvider

--- a/web/src/components/TempoStackDropdown.tsx
+++ b/web/src/components/TempoStackDropdown.tsx
@@ -5,6 +5,8 @@ import {
   SelectVariant,
   SelectOptionObject,
   Spinner,
+  Grid,
+  GridItem,
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 
@@ -86,33 +88,39 @@ export const TempoStackDropdown = (props: TempoStackDropdownProps) => {
   const titleId = 'tempo-stack-select';
   return (
     <div>
-      <span id={titleId} hidden>
-        Select a TempoStack
-      </span>
-      <Select
-        id={props.id}
-        variant={SelectVariant.typeahead}
-        typeAheadAriaLabel={t('Select a TempoStack')}
-        onFilter={tempoStackOptionFilter}
-        onToggle={onToggle}
-        onSelect={onSelect}
-        onClear={clearSelection}
-        selections={selected}
-        isOpen={isOpen}
-        aria-labelledby={titleId}
-        placeholderText={t('Select a TempoStack')}
-        width={400}
-      >
-        {props.isLoading
-          ? [
-              <SelectOption isLoading key="custom-loading" value="loading">
-                <Spinner size="lg" />
-              </SelectOption>,
-            ]
-          : tempoStackSelectOptions.map((option, index) => (
-              <SelectOption key={index} value={option} />
-            ))}
-      </Select>
+      <Grid component="ul">
+        <GridItem component="li">
+          <label htmlFor="tempostack-dropdown">
+            {t('Select a TempoStack')}
+          </label>
+        </GridItem>
+        <GridItem component="li">
+          <Select
+            id={props.id}
+            variant={SelectVariant.typeahead}
+            typeAheadAriaLabel={t('Select a TempoStack')}
+            onFilter={tempoStackOptionFilter}
+            onToggle={onToggle}
+            onSelect={onSelect}
+            onClear={clearSelection}
+            selections={selected}
+            isOpen={isOpen}
+            aria-labelledby={titleId}
+            placeholderText={t('Select a TempoStack')}
+            width={400}
+          >
+            {props.isLoading
+              ? [
+                  <SelectOption isLoading key="custom-loading" value="loading">
+                    <Spinner size="lg" />
+                  </SelectOption>,
+                ]
+              : tempoStackSelectOptions.map((option, index) => (
+                  <SelectOption key={index} value={option} />
+                ))}
+          </Select>
+        </GridItem>
+      </Grid>
     </div>
   );
 };

--- a/web/src/components/TraceTable.tsx
+++ b/web/src/components/TraceTable.tsx
@@ -59,6 +59,7 @@ export const TraceTable: React.FunctionComponent = () => {
   }
 
   const columnNames = {
+    name: 'Name',
     traceId: 'Trace Id',
     durationMs: 'Duration (ms)',
     spanCount: 'Span count',
@@ -75,6 +76,7 @@ export const TraceTable: React.FunctionComponent = () => {
     >
       <Thead>
         <Tr>
+          <Th modifier="wrap">{t(columnNames.name)}</Th>
           <Th modifier="wrap">{t(columnNames.traceId)}</Th>
           <Th modifier="wrap">{t(columnNames.durationMs)}</Th>
           <Th modifier="wrap">{t(columnNames.spanCount)}</Th>
@@ -85,6 +87,7 @@ export const TraceTable: React.FunctionComponent = () => {
       <Tbody>
         {traces.map((trace) => (
           <Tr key={trace.traceId}>
+            <Td dataLabel={columnNames.name}>{trace?.name}</Td>
             <Td dataLabel={columnNames.traceId}>{trace.traceId}</Td>
             <Td dataLabel={columnNames.durationMs}>
               {!trace.durationMs ? '<1ms' : trace.durationMs}

--- a/web/src/components/TracingPage.tsx
+++ b/web/src/components/TracingPage.tsx
@@ -5,15 +5,20 @@ import { useTranslation } from 'react-i18next';
 import { useURLState } from '../hooks/useURLState';
 import { PersesWrapper } from './PersesWrapper';
 import { TempoStackDropdown } from './TempoStackDropdown';
-
 import { useTempoStack } from '../hooks/useTempoStack';
+import { DurationDropdown } from './DurationDropdown';
+import { Grid, GridItem } from '@patternfly/react-core';
+import { DurationString } from '@perses-dev/prometheus-plugin';
 
 export default function TracingPage() {
-  const { tempoStack, namespace, setTempoStackInURL } = useURLState();
-
-  const { loading, tempoStackList } = useTempoStack();
-
   const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
+  const { tempoStack, namespace, setTempoStackInURL } = useURLState();
+  const { loading, tempoStackList } = useTempoStack();
+  const [duration, setDuration] = React.useState<DurationString>('30m');
+
+  const handleDurationChange = (timeRange: DurationString) => {
+    setDuration(timeRange);
+  };
 
   return (
     <>
@@ -29,20 +34,25 @@ export default function TracingPage() {
           <Title headingLevel="h1"> {t('Tracing')} </Title>
         </PageSection>
         <PageSection variant="light">
-          <label htmlFor="tempostack-dropdown">
-            {t('Select a TempoStack')}
-          </label>
-          <TempoStackDropdown
-            id="tempostack-dropdown"
-            tempoStackOptions={tempoStackList}
-            selectedTempoStackName={tempoStack}
-            selectedNamespace={namespace}
-            setTempoList={setTempoStackInURL}
-            isLoading={loading}
-          />
+          <Grid>
+            <GridItem span={7}>
+              <TempoStackDropdown
+                id="tempostack-dropdown"
+                tempoStackOptions={tempoStackList}
+                selectedTempoStackName={tempoStack}
+                selectedNamespace={namespace}
+                setTempoList={setTempoStackInURL}
+                isLoading={loading}
+              />
+            </GridItem>
+            <GridItem span={5}>
+              <DurationDropdown handleDurationChange={handleDurationChange} />
+            </GridItem>
+          </Grid>
           <PersesWrapper
             selectedNamespace={namespace}
             selectedTempoStack={tempoStack}
+            duration={duration}
           />
         </PageSection>
       </Page>


### PR DESCRIPTION
[OU-459](https://issues.redhat.com//browse/OU-459): No UI option to select time period for Traces in distributed-tracing-console plugin
- Add a Time Range option for the user to select the time range of their trace query. Related files are TracingPage.tsx, DurationDropDown.tsx, PersesWrapper.tsx
- Update UI formatting of TempoStackDropDown. Related files are TempoStackDropDown.tsx

[OU-463](https://issues.redhat.com//browse/OU-463): Display the ServiceName for Traces in distributed-tracing-console-plugin UI
- Update TracingTable.tsx to include the name of the trace

Misc.
- Add a script to port-forward the distributed-tracing-console-plugin Pod to utilize the Golang backend in local development. Related files are: MakeFile, start-backend.sh, start-console.sh

<img width="1208" alt="Screenshot 2024-06-24 at 12 16 19 AM" src="https://github.com/openshift/distributed-tracing-console-plugin/assets/59589720/aaf51fb5-4de1-45d2-aa47-b359d76733af">
Figure 1. Dropdown for Time Range of trace query (related to [OU-459](https://issues.redhat.com//browse/OU-459))

<br/>
<br/>

<img width="1440" alt="Screenshot 2024-06-24 at 9 30 20 AM" src="https://github.com/openshift/distributed-tracing-console-plugin/assets/59589720/6b6ca941-c9e7-413b-9125-95a6e8cc95c2">
 Figure 2. Add a column to display the 'Name' of the trace (related to [OU-463](https://issues.redhat.com//browse/OU-463))


