### PR TITLE
Add Trace Detail page (Gantt Chart), upgrade Perses

### DIFF
--- a/hack/disable_webpack_warnings.md
+++ b/hack/disable_webpack_warnings.md
@@ -1,0 +1,10 @@
+## To disable the webpack warning and error overlays (WARNING in shared module react...) while development, add the following:
+```
+client: {
+  overlay: {
+    warnings: false,
+    errors: false,
+  },
+},
+```
+under the `devServer` property in the `webpack.config.ts`.

--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -2,9 +2,9 @@
   {
     "type": "console.page/route",
     "properties": {
-      "exact": true,
+      "exact": false,
       "path": "/observe/traces",
-      "component": { "$codeRef": "TracingPage" }
+      "component": { "$codeRef": "TracingUI" }
     }
   },
   {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,12 +14,12 @@
         "@hookform/resolvers": "^3.3.4",
         "@mui/material": "^5.15.14",
         "@patternfly/react-table": "^5.2.4",
-        "@perses-dev/components": "0.45.0",
-        "@perses-dev/dashboards": "0.45.0",
-        "@perses-dev/panels-plugin": "0.45.0",
-        "@perses-dev/plugin-system": "0.45.0",
-        "@perses-dev/prometheus-plugin": "0.45.0",
-        "@perses-dev/tempo-plugin": "0.45.0",
+        "@perses-dev/components": "0.47.0-rc0",
+        "@perses-dev/dashboards": "0.47.0-rc0",
+        "@perses-dev/panels-plugin": "0.47.0-rc0",
+        "@perses-dev/plugin-system": "0.47.0-rc0",
+        "@perses-dev/prometheus-plugin": "0.47.0-rc0",
+        "@perses-dev/tempo-plugin": "0.47.0-rc0",
         "@tanstack/react-query": "^4.7.1",
         "copy-webpack-plugin": "^12.0.2",
         "i18next": "^23.10.0",
@@ -2916,30 +2916,30 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.15.19",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.19.tgz",
-      "integrity": "sha512-tCHSi/Tomez9ERynFhZRvFO6n9ATyrPs+2N80DMDzp6xDVirbBjEwhPcE+x7Lj+nwYw0SqFkOxyvMP0irnm55w==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.6.tgz",
+      "integrity": "sha512-kytg6LheUG42V8H/o/Ptz3olSO5kUXW9zF0ox18VnblX6bO2yif1FPItgc3ey1t5ansb1+gbe7SatntqusQupg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.15.19",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.19.tgz",
-      "integrity": "sha512-lp5xQBbcRuxNtjpWU0BWZgIrv2XLUz4RJ0RqFXBdESIsKoGCQZ6P3wwU5ZPuj5TjssNiKv9AlM+vHopRxZhvVQ==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.6.tgz",
+      "integrity": "sha512-0LUIKBOIjiFfzzFNxXZBRAyr9UQfmTAFzbt6ziOU2FDXhorNN2o3N9/32mNJbCA8zJo2FqFU6d3dtoqUDyIEfA==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/base": "5.0.0-beta.40",
-        "@mui/core-downloads-tracker": "^5.15.19",
-        "@mui/system": "^5.15.15",
-        "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.15.14",
+        "@mui/core-downloads-tracker": "^5.16.6",
+        "@mui/system": "^5.16.6",
+        "@mui/types": "^7.2.15",
+        "@mui/utils": "^5.16.6",
+        "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.10",
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^18.2.0",
+        "react-is": "^18.3.1",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -2969,12 +2969,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
-      "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.6.tgz",
+      "integrity": "sha512-rAk+Rh8Clg7Cd7shZhyt2HGTTE5wYKNSJ5sspf28Fqm/PZ69Er9o6KX25g03/FG2dfpg5GCwZh/xOojiTfm3hw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.15.14",
+        "@mui/utils": "^5.16.6",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -2995,9 +2995,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
-      "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.6.tgz",
+      "integrity": "sha512-zaThmS67ZmtHSWToTiHslbI8jwrmITcN93LQaR2lKArbvS7Z3iLkwRoiikNWutx9MBs8Q6okKvbZq1RQYB3v7g==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.11.0",
@@ -3026,15 +3026,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.15.15",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.15.tgz",
-      "integrity": "sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.6.tgz",
+      "integrity": "sha512-5xgyJjBIMPw8HIaZpfbGAaFYPwImQn7Nyh+wwKWhvkoIeDosQ1ZMVrbTclefi7G8hNmqhip04duYwYpbBFnBgw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.15.14",
-        "@mui/styled-engine": "^5.15.14",
-        "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.15.14",
+        "@mui/private-theming": "^5.16.6",
+        "@mui/styled-engine": "^5.16.6",
+        "@mui/types": "^7.2.15",
+        "@mui/utils": "^5.16.6",
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -3065,9 +3065,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.14",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
-      "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==",
+      "version": "7.2.15",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.15.tgz",
+      "integrity": "sha512-nbo7yPhtKJkdf9kcVOF8JZHPZTmqXjJ/tI0bdWgHg5tp9AnIN4Y7f7wm9T+0SyGYJk76+GYZ8Q5XaTYAsUHN0Q==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0"
       },
@@ -3078,14 +3078,16 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
-      "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.6.tgz",
+      "integrity": "sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@types/prop-types": "^15.7.11",
+        "@mui/types": "^7.2.15",
+        "@types/prop-types": "^15.7.12",
+        "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3458,15 +3460,15 @@
       "dev": true
     },
     "node_modules/@perses-dev/components": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.45.0.tgz",
-      "integrity": "sha512-mdS+oTkflILB9ry/zigo9q3REWtG+LTDdy4DPBAkpGGrnaDWy/2XtzhKP/oy013Tp7QbRgsyg6jT0AW0t7otlA==",
+      "version": "0.47.0-rc0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.47.0-rc0.tgz",
+      "integrity": "sha512-xOSS0/udUkgNAyU0kV4TP6BkIJ0pyCAqRiJGWMhm1BDtkfmftPlEHKeZDuezHgScz/2Pu7gEordzBPvjQRYiug==",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
         "@fontsource/lato": "^4.5.10",
         "@mui/x-date-pickers": "^6.12.1",
-        "@perses-dev/core": "0.45.0",
-        "@tanstack/react-table": "^8.9.1",
+        "@perses-dev/core": "0.47.0-rc0",
+        "@tanstack/react-table": "^8.19.2",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^1.3.7",
@@ -3478,18 +3480,19 @@
         "react-colorful": "^5.6.1",
         "react-error-boundary": "^3.1.4",
         "react-hook-form": "^7.51.3",
-        "react-virtuoso": "^4.3.6"
+        "react-virtuoso": "^4.3.6",
+        "zod": "^3.21.4"
       },
       "peerDependencies": {
-        "@mui/material": "^5.10.0",
+        "@mui/material": "^5.15.20",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@perses-dev/core": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.45.0.tgz",
-      "integrity": "sha512-rXTUaz0b+DplSMXCiPROQ0+lKrN1j7wtax4q57GpHV9lFFVLyGgakAfD9jbOOcYpnlFXlcqO4JbA0Qh+TBDPUw==",
+      "version": "0.47.0-rc0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.47.0-rc0.tgz",
+      "integrity": "sha512-1nfxchwelzUSDtzsnoMA/+YfoBYLYlpH5ZLhI0s1jfoo2j0nfCc03jMQF0oc4X+MhoNwkwNbETEnsVLKZTQp3w==",
       "dependencies": {
         "date-fns": "^2.28.0",
         "lodash": "^4.17.21",
@@ -3503,13 +3506,13 @@
       }
     },
     "node_modules/@perses-dev/dashboards": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.45.0.tgz",
-      "integrity": "sha512-q+3UQVLfy25YZZ79DgR3PKwlH5V6JJmVhpQeIXtbtSonbDaeODJ8VlIr0oO7hBENbjFyc1pxB+/JK91q2oOBnA==",
+      "version": "0.47.0-rc0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.47.0-rc0.tgz",
+      "integrity": "sha512-UySS9QZL56OZybpkUb+26y+0XrVzEQwgigzq4Rdsi25myQM0rqP+cHrusuZZ3MKGSvIVLSkjaQtF+OCLVzN37A==",
       "dependencies": {
-        "@perses-dev/components": "0.45.0",
-        "@perses-dev/core": "0.45.0",
-        "@perses-dev/plugin-system": "0.45.0",
+        "@perses-dev/components": "0.47.0-rc0",
+        "@perses-dev/core": "0.47.0-rc0",
+        "@perses-dev/plugin-system": "0.47.0-rc0",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^2.28.0",
         "immer": "^9.0.15",
@@ -3523,7 +3526,7 @@
         "zustand": "^4.3.3"
       },
       "peerDependencies": {
-        "@mui/material": "^5.10.0",
+        "@mui/material": "^5.15.20",
         "@tanstack/react-query": "^4.7.1",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
@@ -3552,13 +3555,13 @@
       }
     },
     "node_modules/@perses-dev/panels-plugin": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/panels-plugin/-/panels-plugin-0.45.0.tgz",
-      "integrity": "sha512-H6x8nQm/OUoLtOsYVjBp3Liw5uMWkmfnj7Q58q41KzE79fFgt3gAt28vJ6ipcQ6E2sL89Qp1MLuUH2+gn9f0MA==",
+      "version": "0.47.0-rc0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/panels-plugin/-/panels-plugin-0.47.0-rc0.tgz",
+      "integrity": "sha512-i23XjlMfMfgF0KaetDfdkf1K7X8AMyiNfjZNZBM7p/+07KE51xxXguQCc02M8gjlbk+xafdGo0XOHVF+R7Ihzw==",
       "dependencies": {
-        "@perses-dev/components": "0.45.0",
-        "@perses-dev/core": "0.45.0",
-        "@perses-dev/plugin-system": "0.45.0",
+        "@perses-dev/components": "0.47.0-rc0",
+        "@perses-dev/core": "0.47.0-rc0",
+        "@perses-dev/plugin-system": "0.47.0-rc0",
         "color-hash": "^2.0.2",
         "date-fns": "^2.28.0",
         "dompurify": "^2.4.0",
@@ -3568,18 +3571,18 @@
         "marked": "^4.2.12"
       },
       "peerDependencies": {
-        "@mui/material": "^5.10.0",
+        "@mui/material": "^5.15.20",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@perses-dev/plugin-system": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.45.0.tgz",
-      "integrity": "sha512-LvCHvo/3hh0bs711rOpai6m/4W8K2+p1fYpFVn/sI0S3eSq5hxW1O/dpXqFHC2MSy+nKWzp2TaJvWsA2nmkPZA==",
+      "version": "0.47.0-rc0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.47.0-rc0.tgz",
+      "integrity": "sha512-M3bVvtVJXPgEPXHPZMxBML1FHqVypMS+Cu4AzFuyDfARs9ae+dKJ84A4Gv0lBZq+p7MtymjsCDrhWCSL0VajhQ==",
       "dependencies": {
-        "@perses-dev/components": "0.45.0",
-        "@perses-dev/core": "0.45.0",
+        "@perses-dev/components": "0.47.0-rc0",
+        "@perses-dev/core": "0.47.0-rc0",
         "date-fns": "^2.30.0",
         "immer": "^9.0.15",
         "react-hook-form": "^7.46.1",
@@ -3588,7 +3591,7 @@
         "zod": "^3.22.2"
       },
       "peerDependencies": {
-        "@mui/material": "^5.10.0",
+        "@mui/material": "^5.15.20",
         "@tanstack/react-query": "^4.7.1",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
@@ -3617,32 +3620,33 @@
       }
     },
     "node_modules/@perses-dev/prometheus-plugin": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/prometheus-plugin/-/prometheus-plugin-0.45.0.tgz",
-      "integrity": "sha512-5i7tcf/j/CQ2Lw42/4v0VTYboNPTHWqJ6nHVtFSqsvKr+wMrAczUS11sUVLatGoHDpOkhQGDkSwM3w77rPhT2Q==",
+      "version": "0.47.0-rc0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/prometheus-plugin/-/prometheus-plugin-0.47.0-rc0.tgz",
+      "integrity": "sha512-drWiPphp0pUG7S0iBkxyECch2VtEIL5vX0+BHPDv5byhFiC+ODKobKLdKfY/mjyp1ppx07uzT15vzPB/o6GNsw==",
       "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.2.0",
-        "@perses-dev/components": "0.45.0",
-        "@perses-dev/core": "0.45.0",
-        "@perses-dev/plugin-system": "0.45.0",
+        "@perses-dev/components": "0.47.0-rc0",
+        "@perses-dev/core": "0.47.0-rc0",
+        "@perses-dev/plugin-system": "0.47.0-rc0",
         "@prometheus-io/codemirror-promql": "^0.43.0",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^2.28.0",
-        "immer": "^9.0.15"
+        "immer": "^9.0.15",
+        "react-hook-form": "^7.46.1"
       },
       "peerDependencies": {
         "react": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@perses-dev/tempo-plugin": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/tempo-plugin/-/tempo-plugin-0.45.0.tgz",
-      "integrity": "sha512-OgQGUG/GgBI1ucuaFPbxNo3opWb72cVcPWuBqIS2lloes4HzHUXBZrcL20eU634zHoeLRIh/RzxbIDIari8ggg==",
+      "version": "0.47.0-rc0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/tempo-plugin/-/tempo-plugin-0.47.0-rc0.tgz",
+      "integrity": "sha512-FrXWpSPmgliPvnfIZFtjZ6OL2AjjkzhZUp9j+r8hB2Dzpi6dZfS/B7qxQEtcLx/rTTWFD711bfrf9ukVRhCirg==",
       "dependencies": {
-        "@perses-dev/components": "0.45.0",
-        "@perses-dev/core": "0.45.0",
-        "@perses-dev/plugin-system": "0.45.0"
+        "@perses-dev/components": "0.47.0-rc0",
+        "@perses-dev/core": "0.47.0-rc0",
+        "@perses-dev/plugin-system": "0.47.0-rc0"
       },
       "peerDependencies": {
         "react": "^17.0.2 || ^18.0.0"
@@ -3749,11 +3753,11 @@
       }
     },
     "node_modules/@tanstack/react-table": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.17.3.tgz",
-      "integrity": "sha512-5gwg5SvPD3lNAXPuJJz1fOCEZYk9/GeBFH3w/hCgnfyszOIzwkwgp5I7Q4MJtn0WECp84b5STQUDdmvGi8m3nA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.20.1.tgz",
+      "integrity": "sha512-PJK+07qbengObe5l7c8vCdtefXm8cyR4i078acWrHbdm8JKw1ES7YpmOtVt9ALUVEEFAHscdVpGRhRgikgFMbQ==",
       "dependencies": {
-        "@tanstack/table-core": "8.17.3"
+        "@tanstack/table-core": "8.20.1"
       },
       "engines": {
         "node": ">=12"
@@ -3768,9 +3772,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.17.3.tgz",
-      "integrity": "sha512-mPBodDGVL+fl6d90wUREepHa/7lhsghg2A3vFpakEhrhtbIlgNAZiMr7ccTgak5qbHqF14Fwy+W1yFWQt+WmYQ==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.20.1.tgz",
+      "integrity": "sha512-5Ly5TIRHnWH7vSDell9B/OVyV380qqIJVg7H7R7jU4fPEmOD4smqAX7VRflpYI09srWR8aj5OLD2Ccs1pI5mTg==",
       "engines": {
         "node": ">=12"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -64,7 +64,7 @@
     "displayName": "Distributed Tracing Plugin",
     "description": "This plugin adds a distributed tracing UI to the Openshift console.",
     "exposedModules": {
-      "TracingPage": "./components/TracingPage"
+      "TracingUI": "./TracingUI"
     },
     "dependencies": {
       "@console/pluginAPI": "*"
@@ -76,12 +76,12 @@
     "@hookform/resolvers": "^3.3.4",
     "@mui/material": "^5.15.14",
     "@patternfly/react-table": "^5.2.4",
-    "@perses-dev/components": "0.45.0",
-    "@perses-dev/dashboards": "0.45.0",
-    "@perses-dev/panels-plugin": "0.45.0",
-    "@perses-dev/plugin-system": "0.45.0",
-    "@perses-dev/prometheus-plugin": "0.45.0",
-    "@perses-dev/tempo-plugin": "0.45.0",
+    "@perses-dev/components": "0.47.0-rc0",
+    "@perses-dev/dashboards": "0.47.0-rc0",
+    "@perses-dev/panels-plugin": "0.47.0-rc0",
+    "@perses-dev/plugin-system": "0.47.0-rc0",
+    "@perses-dev/prometheus-plugin": "0.47.0-rc0",
+    "@perses-dev/tempo-plugin": "0.47.0-rc0",
     "@tanstack/react-query": "^4.7.1",
     "copy-webpack-plugin": "^12.0.2",
     "i18next": "^23.10.0",

--- a/web/src/TracingUI.tsx
+++ b/web/src/TracingUI.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Switch, Route } from 'react-router-dom';
+import { TraceDetailPage } from './pages/TraceDetailPage';
+import { TracesPage } from './pages/TracesPage';
+
+export default function TracingUI() {
+  return (
+    <Switch>
+      <Route path="/observe/traces" exact component={TracesPage} />
+      <Route
+        path="/observe/traces/:traceId"
+        exact
+        component={TraceDetailPage}
+      />
+      <Route component={TracesPage} />
+    </Switch>
+  );
+}

--- a/web/src/TracingUI.tsx
+++ b/web/src/TracingUI.tsx
@@ -12,7 +12,6 @@ export default function TracingUI() {
         exact
         component={TraceDetailPage}
       />
-      <Route component={TracesPage} />
     </Switch>
   );
 }

--- a/web/src/components/ErrorAlert.tsx
+++ b/web/src/components/ErrorAlert.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Alert } from '@patternfly/react-core';
+
+export function ErrorAlert({ error }: { error: Error }) {
+  return (
+    <Alert isInline title={error.name} variant="danger">
+      {error.message}
+    </Alert>
+  );
+}

--- a/web/src/components/TraceQueryBrowser.css
+++ b/web/src/components/TraceQueryBrowser.css
@@ -1,11 +1,11 @@
 .tracing-query-browser-input {
-    margin-top: 0.375rem
+  margin-top: 0.375rem;
 }
 
 .tracing-query-browser-stack {
-    margin-top: 2rem
+  margin-top: 2rem;
 }
 
 .tracing-query-browser-input-button {
-    margin-left: 1rem
+  margin-left: 1rem;
 }

--- a/web/src/components/TraceTable.tsx
+++ b/web/src/components/TraceTable.tsx
@@ -12,6 +12,7 @@ import {
 import { useDataQueries } from '@perses-dev/plugin-system';
 import { Title, EmptyState, EmptyStateIcon } from '@patternfly/react-core';
 import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import { Link } from 'react-router-dom';
 
 import { useTranslation } from 'react-i18next';
 
@@ -53,7 +54,7 @@ export const TraceTable: React.FunctionComponent = () => {
     return <LoadingTable />;
   }
 
-  const traces = traceData?.queryResults[0]?.data?.traces;
+  const traces = traceData?.queryResults[0]?.data?.searchResult;
   if (traces === undefined || traces === null || traces.length < 1) {
     return <EmptyTable />;
   }
@@ -87,13 +88,27 @@ export const TraceTable: React.FunctionComponent = () => {
       <Tbody>
         {traces.map((trace) => (
           <Tr key={trace.traceId}>
-            <Td dataLabel={columnNames.name}>{trace?.name}</Td>
+            <Td dataLabel={columnNames.name}>
+              <Link to={traceDetailLink(trace.traceId)}>
+                {trace?.rootServiceName} {trace?.rootTraceName}
+              </Link>
+            </Td>
             <Td dataLabel={columnNames.traceId}>{trace.traceId}</Td>
             <Td dataLabel={columnNames.durationMs}>
               {!trace.durationMs ? '<1ms' : trace.durationMs}
             </Td>
-            <Td dataLabel={columnNames.spanCount}>{trace.spanCount}</Td>
-            <Td dataLabel={columnNames.errorCount}>{trace.errorCount}</Td>
+            <Td dataLabel={columnNames.spanCount}>
+              {Object.values(trace.serviceStats).reduce(
+                (acc, s) => acc + s.spanCount,
+                0,
+              )}
+            </Td>
+            <Td dataLabel={columnNames.errorCount}>
+              {Object.values(trace.serviceStats).reduce(
+                (acc, s) => acc + (s.errorCount ?? 0),
+                0,
+              )}
+            </Td>
             <Td dataLabel={columnNames.startTime}>
               {new Date(trace.startTimeUnixMs).toString()}
             </Td>
@@ -103,3 +118,9 @@ export const TraceTable: React.FunctionComponent = () => {
     </Table>
   );
 };
+
+function traceDetailLink(traceId: string) {
+  return `/observe/traces/${traceId}?${new URLSearchParams(
+    window.location.search,
+  ).toString()}`;
+}

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Divider,
+  Page,
+  PageSection,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router-dom';
+import { TracingGanttChart } from '@perses-dev/panels-plugin';
+import { PersesWrapper } from '../components/PersesWrapper';
+import { useDataQueries } from '@perses-dev/plugin-system';
+import { ErrorBoundary } from '@perses-dev/components';
+import { ErrorAlert } from '../components/ErrorAlert';
+
+interface RouteParams {
+  traceId: string;
+}
+
+export function TraceDetailPage() {
+  const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
+  const { traceId } = useParams<RouteParams>();
+
+  return (
+    <>
+      <HelmetProvider>
+        <Helmet>
+          <title>
+            {traceId} · {t('Tracing')}
+          </title>
+        </Helmet>
+      </HelmetProvider>
+      <Page>
+        <PageSection variant="light">
+          <Stack>
+            <Breadcrumb>
+              <BreadcrumbItem>
+                <Link to="/observe/traces">{t('Traces')}</Link>
+              </BreadcrumbItem>
+              <BreadcrumbItem isActive>{t('Trace details')}</BreadcrumbItem>
+            </Breadcrumb>
+
+            <PersesWrapper
+              queries={[{ kind: 'TempoTraceQuery', spec: { query: traceId } }]}
+            >
+              <Title headingLevel="h1">
+                <TraceTitle />
+              </Title>
+              <Divider className="pf-v5-u-my-md" />
+              <StackItem isFilled>
+                <ErrorBoundary FallbackComponent={ErrorAlert}>
+                  <TracingGanttChart.PanelComponent spec={{}} />
+                </ErrorBoundary>
+              </StackItem>
+            </PersesWrapper>
+          </Stack>
+        </PageSection>
+      </Page>
+    </>
+  );
+}
+
+function TraceTitle() {
+  const { traceId } = useParams<RouteParams>();
+  const { queryResults } = useDataQueries('TraceQuery');
+  const trace = queryResults[0]?.data?.trace;
+
+  if (!trace) {
+    return <>{traceId}</>;
+  }
+  return (
+    <>
+      {trace.rootSpan.resource.serviceName}: {trace.rootSpan.name}
+    </>
+  );
+}

--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -3,18 +3,20 @@ import * as React from 'react';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useURLState } from '../hooks/useURLState';
-import { PersesWrapper } from './PersesWrapper';
-import { TempoStackDropdown } from './TempoStackDropdown';
+import { PersesWrapper } from '../components/PersesWrapper';
+import { TempoStackDropdown } from '../components/TempoStackDropdown';
 import { useTempoStack } from '../hooks/useTempoStack';
-import { DurationDropdown } from './DurationDropdown';
+import { DurationDropdown } from '../components/DurationDropdown';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { DurationString } from '@perses-dev/prometheus-plugin';
+import { TraceQueryBrowser } from '../components/TraceQueryBrowser';
 
-export default function TracingPage() {
+export function TracesPage() {
   const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
   const { tempoStack, namespace, setTempoStackInURL } = useURLState();
   const { loading, tempoStackList } = useTempoStack();
   const [duration, setDuration] = React.useState<DurationString>('30m');
+  const [query, setQuery] = React.useState('{}');
 
   const handleDurationChange = (timeRange: DurationString) => {
     setDuration(timeRange);
@@ -50,10 +52,11 @@ export default function TracingPage() {
             </GridItem>
           </Grid>
           <PersesWrapper
-            selectedNamespace={namespace}
-            selectedTempoStack={tempoStack}
+            queries={[{ kind: 'TempoTraceQuery', spec: { query } }]}
             duration={duration}
-          />
+          >
+            <TraceQueryBrowser setQuery={setQuery} />
+          </PersesWrapper>
         </PageSection>
       </Page>
     </>

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -70,6 +70,12 @@ const config: Configuration = {
     devMiddleware: {
       writeToDisk: true,
     },
+    client: {
+      overlay: {
+        warnings: false,
+        errors: false,
+      },
+    },
   },
   plugins: [
     new ConsoleRemotePlugin(),

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -70,12 +70,6 @@ const config: Configuration = {
     devMiddleware: {
       writeToDisk: true,
     },
-    client: {
-      overlay: {
-        warnings: false,
-        errors: false,
-      },
-    },
   },
   plugins: [
     new ConsoleRemotePlugin(),


### PR DESCRIPTION
* upgrade Perses to v0.47.0-rc0
* support multiple routes (`/observe/traces/:traceId`)
* add `TraceDetailPage` including the `TracingGanttChart` from Perses

Resolves: https://issues.redhat.com/browse/OU-160

## Changes in Perses from 0.46 to 0.47.0-rc0:
Relevant changes:
```
[FEATURE] TracingGanttChart panel (#2047)
[FEATURE] TraceTable panel (#2061)
[FEATURE] TimeRange configurable #2055 (#2071)
[FEATURE] TimeSeries chart: add query-level settings for color override (#2046)
[ENHANCEMENT] Use DateTimeField in DateTimeRangePicker (#2093)
[ENHANCEMENT] update tracing data model (#2058)
[ENHANCEMENT] use relative bubble size in scatter plot (#2059)
[ENHANCEMENT] Increase empty dashboard message width (#2074)
[BUGFIX] Fix TraceQL query escaping (#2128)
[BUGFIX] Check content-type header before parsing error message as JSON (#2096)
[BUGFIX] Fix proxy endpoint that shouldn't be anonymous (#2062)
[BREAKINGCHANGE] Reword "Template Variable" as "Variable" everywhere (#2080)
[BREAKINGCHANGE] Rename various config to use the same wording (#2070)
[BREAKINGCHANGE] Refactor DateTimeRangePicker -> TimeRangeSelector + AbsoluteTimePicker -> DateTimeRangePicker (#2048)
```
Full list of changes: https://github.com/perses/perses/releases/tag/v0.47.0-rc0

## Screenshots
Link:
![grafik](https://github.com/user-attachments/assets/c9cbeeac-7f9d-41f6-a83d-00da7d2a3d80)

TraceDetail page:
![grafik](https://github.com/user-attachments/assets/f9fd4c92-1e17-4c24-9e95-cc8129e2cb20)
![grafik](https://github.com/user-attachments/assets/d78222ef-f3fe-4636-b8c8-0b8f146e8dbd)