### PR TITLE
OU-446: Support FIPS

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,5 @@
-FROM registry.redhat.io/ubi8/nodejs-18:latest AS web-builder
+# This Dockerfile is used for local testing of images. All images should be available for public use
+FROM registry.redhat.io/ubi9/nodejs-18:latest AS web-builder
 
 WORKDIR /opt/app-root
 
@@ -11,7 +12,7 @@ RUN make install-frontend-ci-clean
 COPY web/ web/
 RUN make build-frontend
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 as go-builder
+FROM quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.22-openshift-4.17 as go-builder
 
 WORKDIR /opt/app-root
 
@@ -24,12 +25,9 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-ENV GOEXPERIMENT=strictfipsruntime
-ENV CGO_ENABLED=1
+RUN make build-backend
 
-RUN make build-backend BUILD_OPTS="-tags strictfipsruntime"
-
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-unit-backend:
 
 .PHONY: build-backend
 build-backend:
-	go build -o plugin-backend cmd/plugin-backend.go
+	go build $(BUILD_OPTS) -o plugin-backend -mod=readonly cmd/plugin-backend.go
 
 .PHONY: start-backend
 start-backend:

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This is an OpenShift Console dynamic plugin that adds UI for tracing. This can b
 ### Option 1: Local
 
 **Prerequisite** </br>
-You need to have 
+You need to have
 - a OpenShift Cluster.
-- a [Tempo](https://grafana.com/oss/tempo/) instance. 
+- a [Tempo](https://grafana.com/oss/tempo/) instance.
 
-The current `start-console.sh` script is configured to proxy to a local tempo instance at http://localhost:3200. 
-To change this to a different endpoint modify this line: 
+The current `start-console.sh` script is configured to proxy to a local tempo instance at http://localhost:3200.
+To change this to a different endpoint modify this line:
 
 ```
 # start-console.sh
@@ -83,7 +83,7 @@ push it to an image registry.
 1. Build the image:
 
    ```sh
-   docker build -t quay.io/my-repositroy/my-plugin:latest .
+   docker build -t quay.io/my-repositroy/my-plugin:latest -f Dockerfile.dev .
    ```
 
 2. Run the image:
@@ -119,7 +119,7 @@ Additional parameters can be specified if desired. Consult the chart [values](ch
 Install the chart using the name of the plugin as the Helm release name into a new namespace or an existing namespace as specified by the `my-plugin-namespace` parameter and providing the location of the image within the `plugin.image` parameter by using the following command:
 
 ```shell
-helm upgrade -i  distributed-tracing-console-plugin charts/distributed-tracing-console-plugin -n <my-plugin-namespace> --create-namespace --set plugin.image=<my-plugin-image-location>
+helm upgrade -i distributed-tracing-console-plugin charts/distributed-tracing-console-plugin -n <my-plugin-namespace> --create-namespace --set plugin.image=<my-plugin-image-location>
 ```
 
 For example,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/distributed-tracing-console-plugin
 
-go 1.21
+go 1.22.5
 
 require (
 	github.com/evanphx/json-patch v5.6.0+incompatible

--- a/scripts/build-dev-image.sh
+++ b/scripts/build-dev-image.sh
@@ -1,9 +1,9 @@
-# Terminal output colors 
+# Terminal output colors
 GREEN='\033[0;32m'
 ENDCOLOR='\033[0m' # No Color
 RED='\033[0;31m'
 
-# Environment Variables 
+# Environment Variables
 PREFER_PODMAN="${PREFER_PODMAN:-0}"
 PUSH="${PUSH:-1}"
 TAG="${TAG:-dev}"
@@ -14,11 +14,11 @@ IMAGE=${BASE_IMAGE}:${TAG}
 printf "${GREEN}Environment Varibles ${ENDCOLOR}\n"
 printf "PREFER_PODMAN = ${PREFER_PODMAN}\n"
 printf "PUSH = ${PUSH}\n"
-printf "TAG = ${TAG}\n" 
+printf "TAG = ${TAG}\n"
 printf "REGISTRY_ORG = ${REGISTRY_ORG}\n"
 printf "IMAGE = ${IMAGE}\n"
 
-# User Input to confirm environment variables before proceeding. 
+# User Input to confirm environment variables before proceeding.
 read -p "$(printf "Do these env variables look right? (Y/N): ")" confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
 if [[ -x "$(command -v podman)" && $PREFER_PODMAN == 1 ]]; then
@@ -28,7 +28,7 @@ else
 fi
 
 echo "Building image '${IMAGE}' with ${OCI_BIN}"
-$OCI_BIN build -t $IMAGE --platform=linux/amd64 .
+$OCI_BIN build -t $IMAGE --platform=linux/amd64 -f Dockerfile.dev .
 
 if [[ $PUSH == 1 ]]; then
     echo "Pushing to registry with ${OCI_BIN}"


### PR DESCRIPTION
This PR looks to add FIPS support. It updates the go version to 1.22, and uses recommended FIPS compliant images and tags. Due to some of the recommended images not being available publicly a Dockerfile.dev is added to the repo as a way to build and test images locally.