### PR TITLE
OU-504: Add empty state if Tempo Operator CRDs are not installed or no Tempo instances found

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -101,7 +101,7 @@ func (h *ProxyHandler) createProxy(tempo api.TempoResource, tenant string) (*htt
 
 	var targetURL string
 	switch tempo.Kind {
-	case api.TempoStackKind:
+	case api.KindTempoStack:
 		if len(tempo.Tenants) > 0 {
 			service := DNSName(fmt.Sprintf("tempo-%s-gateway", tempo.Name))
 			targetURL = fmt.Sprintf("https://%s.%s.svc:8080/api/traces/v1/%s/tempo", service, tempo.Namespace, url.PathEscape(tenant))
@@ -110,7 +110,7 @@ func (h *ProxyHandler) createProxy(tempo api.TempoResource, tenant string) (*htt
 			targetURL = fmt.Sprintf("http://%s.%s.svc:3200", service, tempo.Namespace)
 		}
 
-	case api.TempoMonolithicKind:
+	case api.KindTempoMonolithic:
 		if len(tempo.Tenants) > 0 {
 			service := DNSName(fmt.Sprintf("tempo-%s-gateway", tempo.Name))
 			targetURL = fmt.Sprintf("https://%s.%s.svc:8080/api/traces/v1/%s/tempo", service, tempo.Namespace, url.PathEscape(tenant))

--- a/web/i18next-parser.config.js
+++ b/web/i18next-parser.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   createOldCatalogs: false,
   defaultNamespace: 'plugin__distributed-tracing-console-plugin',
+  keySeparator: false,
   locales: ['en'],
   namespaceSeparator: '~',
   reactNamespace: false,

--- a/web/locales/en/plugin__distributed-tracing-console-plugin.json
+++ b/web/locales/en/plugin__distributed-tracing-console-plugin.json
@@ -26,6 +26,16 @@
   "No results found": "No results found",
   "Hide graph": "Hide graph",
   "Show graph": "Show graph",
-  "Clear all filters and try again": "Clear all filters and try again",
+  "Tempo Operator not installed": "Tempo Operator not installed",
+  "Install Tempo Operator": "Install Tempo Operator",
+  "To get started, install the Tempo Operator and create a TempoStack or TempoMonolithic instance with multi-tenancy enabled.": "To get started, install the Tempo Operator and create a TempoStack or TempoMonolithic instance with multi-tenancy enabled.",
+  "Install operator": "Install operator",
+  "Read the documentation": "Read the documentation",
+  "No Tempo instances created yet": "No Tempo instances created yet",
+  "No Tempo instances yet": "No Tempo instances yet",
+  "To get started, create a TempoStack or TempoMonolithic instance with multi-tenancy enabled.": "To get started, create a TempoStack or TempoMonolithic instance with multi-tenancy enabled.",
+  "Create a TempoStack instance": "Create a TempoStack instance",
+  "Error": "Error",
+  "Clear all filters and try again.": "Clear all filters and try again.",
   "Clear all filters": "Clear all filters"
 }

--- a/web/src/components/LoadingState.tsx
+++ b/web/src/components/LoadingState.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Bullseye } from '@patternfly/react-core';
+
+export function LoadingState() {
+  return (
+    <Bullseye>
+      <div className="co-m-loader co-an-fade-in-out" data-test="loading-indicator">
+        <div className="co-m-loader-dot__one" />
+        <div className="co-m-loader-dot__two" />
+        <div className="co-m-loader-dot__three" />
+      </div>
+    </Bullseye>
+  );
+}

--- a/web/src/components/PersesWrapper.tsx
+++ b/web/src/components/PersesWrapper.tsx
@@ -29,8 +29,8 @@ import { TempoInstance } from '../hooks/useTempoInstance';
 import { getProxyURLFor } from '../hooks/api';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ErrorAlert } from './ErrorAlert';
-import { Bullseye } from '@patternfly/react-core';
 import { NoTempoInstanceSelectedState } from './NoTempoInstanceSelectedState';
+import { LoadingState } from './LoadingState';
 
 class DatasourceApiImpl implements DatasourceApi {
   constructor(public proxyDatasource: GlobalDatasourceResource) {}
@@ -156,7 +156,7 @@ export function TraceQueryPanelWrapper({ noResults, children }: TracePanelWrappe
   const { isFetching, isLoading, queryResults } = useDataQueries('TraceQuery');
 
   if (isLoading || isFetching) {
-    return <LoadingOverlay />;
+    return <LoadingState />;
   }
 
   const queryError = queryResults.find((d) => d.error);
@@ -175,17 +175,5 @@ export function TraceQueryPanelWrapper({ noResults, children }: TracePanelWrappe
     <ErrorBoundary FallbackComponent={ErrorAlert} resetKeys={[]}>
       {children}
     </ErrorBoundary>
-  );
-}
-
-function LoadingOverlay() {
-  return (
-    <Bullseye>
-      <div className="co-m-loader co-an-fade-in-out" data-test="loading-indicator">
-        <div className="co-m-loader-dot__one" />
-        <div className="co-m-loader-dot__two" />
-        <div className="co-m-loader-dot__three" />
-      </div>
-    </Bullseye>
   );
 }

--- a/web/src/components/TempoInstanceDropdown.tsx
+++ b/web/src/components/TempoInstanceDropdown.tsx
@@ -37,7 +37,7 @@ export const TempoInstanceDropdown = ({ tempo, setTempo }: TempoInstanceDropdown
   const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
   const { loading: tempoResourcesLoading, tempoResources } = useTempoResources();
   const [isOpen, setIsOpen] = React.useState(false);
-  const options = tempoResources
+  const options = (tempoResources ?? [])
     .map((tempo) => new TempoResourceSelectOption(tempo))
     .sort((a, b) => a.toString().localeCompare(b.toString()));
 

--- a/web/src/pages/TracesPage/QueryBrowser.tsx
+++ b/web/src/pages/TracesPage/QueryBrowser.tsx
@@ -1,0 +1,59 @@
+import React, { memo } from 'react';
+import {
+  Divider,
+  Level,
+  PageSection,
+  Split,
+  SplitItem,
+  Stack,
+  Title,
+} from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { DurationDropdown, DurationValues } from '../../components/DurationDropdown';
+import { QueryEditor } from './QueryEditor/QueryEditor';
+import { TempoInstanceDropdown } from '../../components/TempoInstanceDropdown';
+import { ScatterPlot } from './ScatterPlot';
+import { TraceTable } from './TraceTable';
+import { PersesWrapper } from '../../components/PersesWrapper';
+import { DurationString } from '@perses-dev/core';
+import { createEnumParam, StringParam, useQueryParam, withDefault } from 'use-query-params';
+import { useTempoInstance } from '../../hooks/useTempoInstance';
+
+const durationQueryParam = withDefault(createEnumParam(DurationValues), '30m');
+
+// use memo() to prevent re-rendering (and flickering) of this page once
+// the parent component loaded the list of Tempo resources in the cluster
+export const QueryBrowser = memo(function QueryBrowser() {
+  const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
+  const [tempo, setTempo] = useTempoInstance();
+  const [query, setQuery] = useQueryParam('q', withDefault(StringParam, '{}'));
+  const [duration, setDuration] = useQueryParam('duration', durationQueryParam, {
+    updateType: 'replaceIn',
+  });
+
+  return (
+    <PageSection variant="light">
+      <Stack hasGutter>
+        <Level hasGutter>
+          <Title headingLevel="h1">{t('Traces')}</Title>
+          <DurationDropdown duration={duration as DurationString} setDuration={setDuration} />
+        </Level>
+        <Divider />
+        <Split hasGutter>
+          <TempoInstanceDropdown tempo={tempo} setTempo={setTempo} />
+          <SplitItem isFilled>
+            <QueryEditor query={query} setQuery={setQuery} />
+          </SplitItem>
+        </Split>
+        <PersesWrapper
+          tempo={tempo}
+          definitions={[{ kind: 'TempoTraceQuery', spec: { query } }]}
+          duration={duration as DurationString}
+        >
+          <ScatterPlot />
+          <TraceTable setQuery={setQuery} />
+        </PersesWrapper>
+      </Stack>
+    </PageSection>
+  );
+});

--- a/web/src/pages/TracesPage/TracesPage.tsx
+++ b/web/src/pages/TracesPage/TracesPage.tsx
@@ -1,35 +1,36 @@
 import React from 'react';
+import { useTempoResources } from '../../hooks/useTempoResources';
+import { QueryBrowser } from './QueryBrowser';
 import {
+  Bullseye,
+  Button,
   Divider,
-  Level,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
   Page,
   PageSection,
-  Split,
-  SplitItem,
   Stack,
   Title,
 } from '@patternfly/react-core';
-import { Helmet, HelmetProvider } from 'react-helmet-async';
+import { PlusCircleIcon, WrenchIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { DurationDropdown, DurationValues } from '../../components/DurationDropdown';
-import { QueryEditor } from './QueryEditor/QueryEditor';
-import { TempoInstanceDropdown } from '../../components/TempoInstanceDropdown';
-import { ScatterPlot } from './ScatterPlot';
-import { TraceTable } from './TraceTable';
-import { PersesWrapper } from '../../components/PersesWrapper';
-import { DurationString } from '@perses-dev/core';
-import { createEnumParam, StringParam, useQueryParam, withDefault } from 'use-query-params';
 import { useTempoInstance } from '../../hooks/useTempoInstance';
+import { ErrorAlert } from '../../components/ErrorAlert';
+import { LoadingState } from '../../components/LoadingState';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
 
-const durationQueryParam = withDefault(createEnumParam(DurationValues), '30m');
+const installOperatorLink =
+  '/operatorhub/all-namespaces?keyword=Tempo&details-item=tempo-product-redhat-operators-openshift-marketplace';
+const createTempoInstanceLink =
+  '/api-resource/all-namespaces/tempo.grafana.com~v1alpha1~TempoStack/instances';
+const readInstallationDocsLink =
+  'https://docs.openshift.com/container-platform/4.16/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.html';
 
 export function TracesPage() {
   const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
-  const [tempo, setTempo] = useTempoInstance();
-  const [query, setQuery] = useQueryParam('q', withDefault(StringParam, '{}'));
-  const [duration, setDuration] = useQueryParam('duration', durationQueryParam, {
-    updateType: 'replaceIn',
-  });
 
   return (
     <>
@@ -39,30 +40,120 @@ export function TracesPage() {
         </Helmet>
       </HelmetProvider>
       <Page>
-        <PageSection variant="light">
-          <Stack hasGutter>
-            <Level hasGutter>
-              <Title headingLevel="h1">{t('Traces')}</Title>
-              <DurationDropdown duration={duration as DurationString} setDuration={setDuration} />
-            </Level>
-            <Divider />
-            <Split hasGutter>
-              <TempoInstanceDropdown tempo={tempo} setTempo={setTempo} />
-              <SplitItem isFilled>
-                <QueryEditor query={query} setQuery={setQuery} />
-              </SplitItem>
-            </Split>
-            <PersesWrapper
-              tempo={tempo}
-              definitions={[{ kind: 'TempoTraceQuery', spec: { query } }]}
-              duration={duration as DurationString}
-            >
-              <ScatterPlot />
-              <TraceTable setQuery={setQuery} />
-            </PersesWrapper>
-          </Stack>
-        </PageSection>
+        <TracesPageBody />
       </Page>
     </>
+  );
+}
+
+// TracesPageBody handles empty states like "Tempo Operator not installed" or "No Tempo instances created yet".
+function TracesPageBody() {
+  const { loading, error, tempoResources } = useTempoResources();
+  const [tempo] = useTempoInstance();
+
+  // show loading state (loading the list of Tempo CRs in the cluster)
+  // only if no Tempo instance is selected (from the query params)
+  if (!tempo && loading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    if (error.errorType === 'TempoCRDNotFound') {
+      return <TempoOperatorNotInstalledState />;
+    } else {
+      return <ErrorState errorType={error.errorType} error={error.error} />;
+    }
+  }
+
+  if (!loading && tempoResources && tempoResources.length === 0) {
+    return <NoTempoInstance />;
+  }
+
+  return <QueryBrowser />;
+}
+
+function TempoOperatorNotInstalledState() {
+  const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
+  return (
+    <>
+      <PageSection variant="light">
+        <Title headingLevel="h1">{t('Traces')}</Title>
+      </PageSection>
+      <PageSection>
+        <Bullseye>
+          <EmptyState>
+            <EmptyStateIcon icon={WrenchIcon} />
+            <Title headingLevel="h2" size="lg">
+              {t('Install Tempo Operator')}
+            </Title>
+            <EmptyStateBody>
+              {t(
+                'To get started, install the Tempo Operator and create a TempoStack or TempoMonolithic instance with multi-tenancy enabled.',
+              )}
+            </EmptyStateBody>
+            <Button component={(props) => <Link {...props} to={installOperatorLink} />}>
+              {t('Install operator')}
+            </Button>
+            <EmptyStateSecondaryActions>
+              <Button variant="link" component="a" href={readInstallationDocsLink}>
+                {t('Read the documentation')}
+              </Button>
+            </EmptyStateSecondaryActions>
+          </EmptyState>
+        </Bullseye>
+      </PageSection>
+    </>
+  );
+}
+
+function NoTempoInstance() {
+  const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
+  return (
+    <>
+      <PageSection variant="light">
+        <Title headingLevel="h1">{t('Traces')}</Title>
+      </PageSection>
+      <PageSection>
+        <Bullseye>
+          <EmptyState>
+            <EmptyStateIcon icon={PlusCircleIcon} />
+            <Title headingLevel="h2" size="lg">
+              {t('No Tempo instances yet')}
+            </Title>
+            <EmptyStateBody>
+              {t(
+                'To get started, create a TempoStack or TempoMonolithic instance with multi-tenancy enabled.',
+              )}
+            </EmptyStateBody>
+            <Button component={(props) => <Link {...props} to={createTempoInstanceLink} />}>
+              {t('Create a TempoStack instance')}
+            </Button>
+            <EmptyStateSecondaryActions>
+              <Button variant="link" component="a" href={readInstallationDocsLink}>
+                {t('Read the documentation')}
+              </Button>
+            </EmptyStateSecondaryActions>
+          </EmptyState>
+        </Bullseye>
+      </PageSection>
+    </>
+  );
+}
+
+interface ErrorStateProps {
+  errorType?: string;
+  error: string;
+}
+
+function ErrorState({ errorType, error }: ErrorStateProps) {
+  const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
+  return (
+    <PageSection variant="light">
+      <Stack hasGutter>
+        <Title headingLevel="h1">{t('Tracing')}</Title>
+        <Divider />
+        <ErrorAlert error={{ name: errorType ?? t('Error'), message: error }} />
+      </Stack>
+    </PageSection>
   );
 }


### PR DESCRIPTION
## Backend changes
* return errors as JSON
* handle resource not found error (i.e. Tempo Operator not installed)

## Frontend changes
* show empty states for operator not installed and no Tempo instance
  found
* move main UI to QueryBrowser.tsx

Resolves: https://issues.redhat.com/browse/OU-504

## Screenshots
![image](https://github.com/user-attachments/assets/3b3a666d-fb3d-4ef4-8ab2-b3febd20d1f8)
![image](https://github.com/user-attachments/assets/66583bcf-5723-46e9-97af-a4f4588e4b12)
