### PR TITLE
OU-517: Support re-running unchanged query

### DIFF
--- a/web/src/pages/TracesPage/QueryEditor/QueryEditor.tsx
+++ b/web/src/pages/TracesPage/QueryEditor/QueryEditor.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 interface QueryEditorProps {
   query: string;
-  setQuery: (query: string) => void;
+  runQuery: (query: string) => void;
 }
 
 export function QueryEditor(props: QueryEditorProps) {
@@ -25,7 +25,7 @@ export function QueryEditor(props: QueryEditorProps) {
       <label htmlFor="traceql-input">{t('Query')}</label>
       <Split hasGutter>
         <TraceQLEditor query={pendingQuery} setQuery={setPendingQuery} />
-        <Button variant="primary" onClick={() => props.setQuery(pendingQuery)}>
+        <Button variant="primary" onClick={() => props.runQuery(pendingQuery)}>
           {t('Run query')}
         </Button>
       </Split>

--- a/web/src/pages/TracesPage/TraceTable.tsx
+++ b/web/src/pages/TracesPage/TraceTable.tsx
@@ -13,10 +13,10 @@ import { SearchIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 
 interface TraceTableProps {
-  setQuery: (query: string) => void;
+  runQuery: (query: string) => void;
 }
 
-export function TraceTable({ setQuery }: TraceTableProps) {
+export function TraceTable({ runQuery }: TraceTableProps) {
   const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
 
   const noResults = (
@@ -27,7 +27,7 @@ export function TraceTable({ setQuery }: TraceTableProps) {
           {t('No results found')}
         </Title>
         <EmptyStateBody>{t('Clear all filters and try again.')}</EmptyStateBody>
-        <Button variant="link" onClick={() => setQuery('{}')}>
+        <Button variant="link" onClick={() => runQuery('{}')}>
           {t('Clear all filters')}
         </Button>
       </EmptyState>


### PR DESCRIPTION
The duration dropdown is relative ("last 5 minutes"), therefore re-running an unchanged query should always refresh the search results with the current time frame (e.g. last 5 minutes until now).

Resolves: https://issues.redhat.com/browse/OU-517