### PR TITLE
OU-536: Support dark mode

### DIFF
--- a/web/src/components/PersesWrapper.tsx
+++ b/web/src/components/PersesWrapper.tsx
@@ -31,6 +31,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { ErrorAlert } from './ErrorAlert';
 import { NoTempoInstanceSelectedState } from './NoTempoInstanceSelectedState';
 import { LoadingState } from './LoadingState';
+import { getConsoleThemeName } from './console/utils/theme';
 
 class DatasourceApiImpl implements DatasourceApi {
   constructor(public proxyDatasource: GlobalDatasourceResource) {}
@@ -59,7 +60,7 @@ const patternflyBlue500 = '#004080';
 const patternflyBlue600 = '#002952';
 const defaultPaletteColors = [patternflyBlue400, patternflyBlue500, patternflyBlue600];
 
-const muiTheme = getTheme('light');
+const muiTheme = getTheme(getConsoleThemeName());
 muiTheme.shape.borderRadius = 0;
 
 const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, {

--- a/web/src/components/console/utils/theme.ts
+++ b/web/src/components/console/utils/theme.ts
@@ -1,0 +1,12 @@
+const PF_THEME_DARK_CLASS = 'pf-v5-theme-dark';
+const PF_THEME_DARK_CLASS_LEGACY = 'pf-theme-dark'; // legacy class name needed to support PF4
+
+// The @openshift-console/dynamic-plugin-sdk package does not expose the theme,
+// therefore check if the root <html> element has the PatternFly css class set for the dark theme.
+export function getConsoleThemeName(): 'light' | 'dark' {
+  const classList = document.documentElement.classList;
+  if (classList.contains(PF_THEME_DARK_CLASS) || classList.contains(PF_THEME_DARK_CLASS_LEGACY)) {
+    return 'dark';
+  }
+  return 'light';
+}


### PR DESCRIPTION
Switch to Perses dark theme if the dark theme is enabled.
Resolves: https://issues.redhat.com/browse/OU-536

## Screenshots
![image](https://github.com/user-attachments/assets/d82f8b8e-5028-449a-945b-1992346f66dd)
![image](https://github.com/user-attachments/assets/3881d431-2748-4dd6-b9c5-2e694768da42)
