### PR TITLE
OU-542: Use PatternFly font for Perses components

### DIFF
--- a/web/src/components/PersesWrapper.tsx
+++ b/web/src/components/PersesWrapper.tsx
@@ -4,6 +4,7 @@ import {
   generateChartsTheme,
   getTheme,
   PersesChartsTheme,
+  typography,
 } from '@perses-dev/components';
 import { ThemeProvider } from '@mui/material';
 import {
@@ -90,8 +91,15 @@ interface PersesWrapperProps {
 export function PersesWrapper({ children }: PersesWrapperProps) {
   const { theme } = usePatternFlyTheme();
 
-  const muiTheme = getTheme(theme);
-  muiTheme.shape.borderRadius = 0;
+  const muiTheme = getTheme(theme, {
+    typography: {
+      ...typography,
+      fontFamily: 'var(--pf-v5-global--FontFamily--text)',
+    },
+    shape: {
+      borderRadius: 0,
+    },
+  });
 
   const chartsTheme: PersesChartsTheme = generateChartsTheme(muiTheme, {
     thresholds: {


### PR DESCRIPTION
[OU-542](https://issues.redhat.com//browse/OU-542): Use PatternFly font for Perses components
Resolves: https://issues.redhat.com/browse/OU-542