### PR TITLE
Use TimeRangeProvider to manipulate time range

### DIFF
--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -15,6 +15,7 @@ import { Link, useLocation, useParams } from 'react-router-dom';
 import { TracingGanttChart } from '@perses-dev/panels-plugin';
 import {
   PersesDashboardWrapper,
+  PersesTempoDatasourceWrapper,
   PersesWrapper,
   TraceQueryPanelWrapper,
 } from '../components/PersesWrapper';
@@ -52,22 +53,24 @@ export function TraceDetailPage() {
             </Breadcrumb>
 
             <PersesWrapper>
-              <PersesDashboardWrapper
-                tempo={tempo}
-                definitions={[{ kind: 'TempoTraceQuery', spec: { query: traceId } }]}
-              >
-                <Title headingLevel="h1">
-                  <TraceTitle />
-                </Title>
-                <Divider className="pf-v5-u-my-md" />
-                <StackItem isFilled>
-                  <TraceQueryPanelWrapper>
-                    <TracingGanttChart.PanelComponent
-                      spec={{ visual: { palette: { mode: 'categorical' } } }}
-                      attributeLinks={attributeLinks}
-                    />
-                  </TraceQueryPanelWrapper>
-                </StackItem>
+              <PersesDashboardWrapper>
+                <PersesTempoDatasourceWrapper
+                  tempo={tempo}
+                  queries={[{ kind: 'TempoTraceQuery', spec: { query: traceId } }]}
+                >
+                  <Title headingLevel="h1">
+                    <TraceTitle />
+                  </Title>
+                  <Divider className="pf-v5-u-my-md" />
+                  <StackItem isFilled>
+                    <TraceQueryPanelWrapper>
+                      <TracingGanttChart.PanelComponent
+                        spec={{ visual: { palette: { mode: 'categorical' } } }}
+                        attributeLinks={attributeLinks}
+                      />
+                    </TraceQueryPanelWrapper>
+                  </StackItem>
+                </PersesTempoDatasourceWrapper>
               </PersesDashboardWrapper>
             </PersesWrapper>
           </Stack>


### PR DESCRIPTION
Previously, every change to the query resulted in two Tempo API calls, because the <TimeRangeProvider> component of the <PersesDashboardWrapper> received a new object for the `timeRange` prop on every render, resulting in two re-renders:

(1) due to a change in props and
(2) due to a change in the first hook (localTimeRange):
```
useEffect(() => {
  setLocalTimeRange(timeRange);
}, [timeRange, refreshCounter]);
```

This change moves the <TimeRangeProvider> up and uses its exposed methods to update and refresh the current time range. This results in a single Tempo API call per search.