### PR TITLE
NO-JIRA: [chore] fix build-time warnings

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.15.14",
         "@patternfly/react-charts": "6.92.0",
         "@patternfly/react-core": "^5.4.13",
+        "@patternfly/react-icons": "^5.4.2",
         "@perses-dev/components": "0.49.0-rc.1",
         "@perses-dev/dashboards": "0.49.0-rc.1",
         "@perses-dev/panels-plugin": "0.49.0-rc.1",

--- a/web/package.json
+++ b/web/package.json
@@ -77,6 +77,7 @@
     "@mui/material": "^5.15.14",
     "@patternfly/react-core": "^5.4.13",
     "@patternfly/react-charts": "6.92.0",
+    "@patternfly/react-icons": "^5.4.2",
     "@perses-dev/components": "0.49.0-rc.1",
     "@perses-dev/dashboards": "0.49.0-rc.1",
     "@perses-dev/panels-plugin": "0.49.0-rc.1",

--- a/web/src/components/TypeaheadSelect.tsx
+++ b/web/src/components/TypeaheadSelect.tsx
@@ -12,7 +12,7 @@ import {
   Button,
   Spinner,
 } from '@patternfly/react-core';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import { TimesIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 
 interface TypeaheadSelectProps {


### PR DESCRIPTION
Fixes the following warnings:

```
LOG from @openshift-console/dynamic-plugin-sdk-webpack/lib/webpack/loaders/dynamic-module-import-loader ../node_modules/ts-loader/index.js??ruleSet[1].rules[0].use[0]!./components/TypeaheadSelect.tsx
<w> Non-index and non-dynamic module import @patternfly/react-icons/dist/esm/icons/times-icon
```

and

```
WARNING in shared module @patternfly/react-icons/dist/dynamic/icons/plus-circle-icon
No required version specified and unable to automatically determine one. Unable to find required version for "@patternfly/react-icons" in description file (/home/agerstmayr/redhat/dev/distributed-tracing-console-plugin/web/package.json). It need to be in dependencies, devDependencies or peerDependencies.
```