### PR TITLE
COO-362: [Chore] Update Cypress base image

### DIFF
--- a/tests/Dockerfile-cypress
+++ b/tests/Dockerfile-cypress
@@ -14,3 +14,7 @@ RUN wget -O chainsaw.tar.gz https://github.com/kyverno/chainsaw/releases/downloa
     && chmod +x chainsaw \
     && mv chainsaw /usr/local/bin/ \
     && rm -rf chainsaw.tar.gz
+
+# Install apache2-utils for htpasswd required by OCP CI
+RUN apt update && apt install -y apache2-utils \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Update the Dockerfile to install apache2-utils to use htpasswd for creating IDP users. 