### PR TITLE
OU-805: account for selected time range when showing attribute values

### DIFF
--- a/web/src/hooks/useTagValues.ts
+++ b/web/src/hooks/useTagValues.ts
@@ -8,14 +8,16 @@ export function useTagValues(
   tag: string,
   query: string,
   enabled: boolean,
+  start?: number,
+  end?: number,
 ) {
   return useQuery({
-    queryKey: ['useTagValues', tempo, tag, query],
+    queryKey: ['useTagValues', tempo, tag, query, start, end],
     enabled,
     queryFn: async function () {
       if (!tempo) return [];
       const client = TempoDatasource.createClient({ directUrl: getProxyURLFor(tempo) }, {});
-      const values = await client.searchTagValues({ tag, q: query });
+      const values = await client.searchTagValues({ tag, q: query, start, end });
       return values.tagValues
         .map((tagValue) => ({
           content: tagValue.value,

--- a/web/src/pages/TracesPage/Toolbar/AttributeFilters.tsx
+++ b/web/src/pages/TracesPage/Toolbar/AttributeFilters.tsx
@@ -21,6 +21,8 @@ import { traceQLToFilter } from './Filter/traceql_to_filter';
 import { TypeaheadCheckboxSelect } from '../../../components/TypeaheadCheckboxSelect';
 import { DurationField, Filter, splitByUnquotedWhitespace } from './Filter/filter';
 import { useTagValues } from '../../../hooks/useTagValues';
+import { useTimeRange } from '@perses-dev/plugin-system';
+import { isAbsoluteTimeRange, toAbsoluteTimeRange } from '@perses-dev/core';
 
 const serviceNameFilter = { content: 'Service Name', value: 'serviceName' };
 const spanNameFilter = { content: 'Span Name', value: 'spanName' };
@@ -63,23 +65,34 @@ export function AttributeFilters(props: AttributeFiltersProps) {
     setQuery(filterToTraceQL(filter));
   };
 
+  const { timeRange } = useTimeRange();
+  const absTimeRange = !isAbsoluteTimeRange(timeRange) ? toAbsoluteTimeRange(timeRange) : timeRange;
+  const startTime = Math.round(absTimeRange.start.getTime() / 1000);
+  const endTime = Math.round(absTimeRange.end.getTime() / 1000);
+
   const { data: serviceNameOptions } = useTagValues(
     tempo,
     'resource.service.name',
     filterToTraceQL({ ...filter, serviceName: [] }),
     activeFilter === serviceNameFilter.value,
+    startTime,
+    endTime,
   );
   const { data: spanNameOptions } = useTagValues(
     tempo,
     'name',
     filterToTraceQL({ ...filter, spanName: [] }),
     activeFilter === spanNameFilter.value,
+    startTime,
+    endTime,
   );
   const { data: namespaceOptions } = useTagValues(
     tempo,
     'resource.k8s.namespace.name',
     filterToTraceQL({ ...filter, namespace: [] }),
     activeFilter === namespaceFilter.value,
+    startTime,
+    endTime,
   );
 
   return (


### PR DESCRIPTION
Account for selected time range when showing attribute values in the filter bar.
Otherwise, by default, only tag values of the last 15 minutes or so are shown.