### PR TITLE
NO-JIRA: improve API handling

### DIFF
--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Response struct {
+	Status    StatusType `json:"status"`
+	ErrorType string     `json:"errorType,omitempty"`
+	Error     string     `json:"error,omitempty"`
+	Data      any        `json:"data,omitempty"`
+}
+
+type StatusType string
+
+const (
+	StatusSuccess StatusType = "success"
+	StatusError   StatusType = "error"
+)
+
+func writeResponse(w http.ResponseWriter, code int, r Response) {
+	if r.Status != StatusSuccess {
+		log.Error(fmt.Sprintf("type=%s, error=%s", r.ErrorType, r.Error))
+	}
+
+	bytes, err := json.Marshal(r)
+	if err != nil {
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(bytes)
+}

--- a/web/locales/en/plugin__distributed-tracing-console-plugin.json
+++ b/web/locales/en/plugin__distributed-tracing-console-plugin.json
@@ -43,6 +43,7 @@
   "TraceQL Query": "TraceQL Query",
   "Query": "Query",
   "Run query": "Run query",
+  "Error connecting to the Tracing UI plugin backend": "Error connecting to the Tracing UI plugin backend",
   "Tempo operator isn't installed yet": "Tempo operator isn't installed yet",
   "To get started, install the Tempo operator and create a TempoStack or TempoMonolithic instance with multi-tenancy enabled.": "To get started, install the Tempo operator and create a TempoStack or TempoMonolithic instance with multi-tenancy enabled.",
   "Install Tempo operator": "Install Tempo operator",
@@ -53,6 +54,7 @@
   "Create a TempoMonolithic instance": "Create a TempoMonolithic instance",
   "View documentation": "View documentation",
   "Error": "Error",
+  "Unknown error": "Unknown error",
   "No results found": "No results found",
   "No results match this query criteria. Clear all filters and try again.": "No results match this query criteria. Clear all filters and try again.",
   "Clear all filters": "Clear all filters"

--- a/web/src/cancellable-fetch.ts
+++ b/web/src/cancellable-fetch.ts
@@ -66,7 +66,10 @@ export const cancellableFetch = <T>(
   }
 
   const timeoutPromise = new Promise<T>((_resolve, reject) => {
-    setTimeout(() => reject(new TimeoutError(url.toString(), timeout)), timeout);
+    setTimeout(() => {
+      abort();
+      reject(new TimeoutError(url.toString(), timeout));
+    }, timeout);
   });
 
   const request = () => Promise.race([fetchPromise, timeoutPromise]);

--- a/web/src/components/TempoInstanceDropdown.tsx
+++ b/web/src/components/TempoInstanceDropdown.tsx
@@ -20,7 +20,7 @@ interface TempoResourceOption extends TypeaheadSelectOption {
 
 export const TempoInstanceDropdown = ({ tempo, setTempo }: TempoInstanceDropdownProps) => {
   const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
-  const { loading: tempoResourcesLoading, tempoResources } = useTempoResources();
+  const { isLoading, data: tempoResources } = useTempoResources();
 
   const options: TempoResourceOption[] = (tempoResources ?? [])
     .map((tempo) => ({
@@ -33,7 +33,7 @@ export const TempoInstanceDropdown = ({ tempo, setTempo }: TempoInstanceDropdown
 
   let selected: TempoResourceOption | undefined = undefined;
   if (tempo) {
-    if (tempoResourcesLoading) {
+    if (isLoading) {
       // Preselect the dropdown option without waiting until the list of TempoResources is loaded to prevent flickering.
       // To accomplish this, we'll create a slightly inaccurate TempoResourceSelectOption,
       // because the kind and the list of tenants is not known before the list of TempoResources is loaded.
@@ -99,7 +99,7 @@ export const TempoInstanceDropdown = ({ tempo, setTempo }: TempoInstanceDropdown
               toggleWidth="22em"
               placeholder={t('Select a Tempo instance')}
               allowClear={false}
-              loading={tempoResourcesLoading}
+              loading={isLoading}
               options={options}
               value={selected?.value}
               setValue={onSelect}

--- a/web/src/hooks/api.ts
+++ b/web/src/hooks/api.ts
@@ -2,6 +2,13 @@ import { TempoInstance } from './useTempoInstance';
 
 export const BACKEND_URL = '/api/proxy/plugin/distributed-tracing-console-plugin/backend';
 
+export interface APIResponse<T> {
+  status: 'success' | 'error';
+  errorType?: string;
+  error?: string;
+  data?: T;
+}
+
 export function getProxyURLFor(tempo: TempoInstance) {
   return `${BACKEND_URL}/proxy/${encodeURIComponent(tempo.namespace)}/${encodeURIComponent(
     tempo.name,

--- a/web/src/hooks/useTempoResources.ts
+++ b/web/src/hooks/useTempoResources.ts
@@ -1,6 +1,6 @@
-import * as React from 'react';
 import { cancellableFetch, FetchError } from '../cancellable-fetch';
-import { BACKEND_URL } from './api';
+import { APIResponse, BACKEND_URL } from './api';
+import { useQuery } from '@tanstack/react-query';
 
 /**
  * Definition of a TempoStack or TempoMonolithic Custom Resource in the cluster.
@@ -14,12 +14,7 @@ export type TempoResource = {
   tenants?: string[];
 };
 
-interface ListTempoResourcesResponse {
-  status: 'success' | 'error';
-  data: TempoResource[];
-  errorType?: string;
-  error?: string;
-}
+type ListTempoResourcesResponse = APIResponse<TempoResource[]>;
 
 const isTempoStackListResponse = (value: unknown): value is TempoResource => {
   const obj = value as TempoResource;
@@ -31,51 +26,26 @@ const isTempoStackListResponse = (value: unknown): value is TempoResource => {
   );
 };
 
-export const useTempoResources = () => {
-  const [tempoResources, setTempoResources] = React.useState<Array<TempoResource>>();
-  const [error, setError] = React.useState<{ errorType?: string; error: string } | undefined>();
-  const [loading, setLoading] = React.useState<boolean>(false);
+export function useTempoResources() {
+  return useQuery<TempoResource[], FetchError>({
+    queryKey: ['useTempoResources'],
+    queryFn: async function () {
+      const { request } = cancellableFetch<ListTempoResourcesResponse>(
+        `${BACKEND_URL}/api/v1/list-tempo-resources`,
+      );
+      const response = await request();
 
-  React.useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-
-        const { request } = cancellableFetch<ListTempoResourcesResponse>(
-          `${BACKEND_URL}/api/v1/list-tempo-resources`,
-        );
-        const response = await request();
-
-        if (
-          response &&
-          response.status === 'success' &&
-          Array.isArray(response.data) &&
-          response.data.every(isTempoStackListResponse)
-        ) {
-          setTempoResources(response.data);
-          setError(undefined);
-        } else {
-          throw new FetchError('Error retrieving Tempo resources', 500, response);
-        }
-      } catch (e) {
-        setTempoResources(undefined);
-        if (e instanceof FetchError && e.json?.error) {
-          setError(e.json);
-        } else {
-          setError({ error: String(e) });
-        }
-        console.error(e);
-      } finally {
-        setLoading(false);
+      if (
+        response &&
+        response.status === 'success' &&
+        Array.isArray(response.data) &&
+        response.data.every(isTempoStackListResponse)
+      ) {
+        return response.data;
+      } else {
+        throw new FetchError('Error retrieving Tempo resources', 500, response);
       }
-    };
-
-    fetchData();
-  }, []);
-
-  return {
-    loading,
-    error,
-    tempoResources,
-  };
-};
+    },
+    staleTime: 60 * 1000, // cache response for 1m
+  });
+}

--- a/web/src/pages/TracesPage/TracesPage.tsx
+++ b/web/src/pages/TracesPage/TracesPage.tsx
@@ -52,24 +52,30 @@ export default memo(TracesPage);
  * and shows an empty state instead of the query browser.
  */
 function TracesPageBody() {
-  const { loading, error, tempoResources } = useTempoResources();
+  const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
+  const { isLoading, error, data: tempoResources } = useTempoResources();
   const [tempo] = useTempoInstance();
 
   // show loading state (loading the list of Tempo CRs in the cluster)
   // only if no Tempo instance is selected (from the query params)
-  if (!tempo && loading) {
+  if (!tempo && isLoading) {
     return <LoadingState />;
   }
 
   if (error) {
-    if (error.errorType === 'TempoCRDNotFound') {
+    if (error.json?.errorType === 'TempoCRDNotFound') {
       return <TempoOperatorNotInstalledState />;
     } else {
-      return <ErrorState errorType={error.errorType} error={error.error} />;
+      return (
+        <ErrorState
+          errorType={error.json?.errorType}
+          error={error.json?.error ?? t('Error connecting to the Tracing UI plugin backend')}
+        />
+      );
     }
   }
 
-  if (!loading && tempoResources && tempoResources.length === 0) {
+  if (!isLoading && tempoResources && tempoResources.length === 0) {
     return <NoTempoInstance />;
   }
 
@@ -169,7 +175,7 @@ function NoTempoInstance() {
 
 interface ErrorStateProps {
   errorType?: string;
-  error: string;
+  error?: string;
 }
 
 function ErrorState({ errorType, error }: ErrorStateProps) {
@@ -180,7 +186,9 @@ function ErrorState({ errorType, error }: ErrorStateProps) {
         <Title headingLevel="h1">{t('Traces')}</Title>
       </PageSection>
       <PageSection>
-        <ErrorAlert error={{ name: errorType ?? t('Error'), message: error }} />
+        <ErrorAlert
+          error={{ name: errorType ?? t('Error'), message: error ?? t('Unknown error') }}
+        />
       </PageSection>
     </>
   );


### PR DESCRIPTION
* extract response schema into common.go/api.ts
* abort query if timeout is reached
* use @tanstack/query instead of custom code for fetching Tempo CRs
* cache list-tempo-resources API response
* show error message if plugin backend is not reachable