### PR TITLE
TRACING-5604: Upgrade Perses to v0.52.0-rc.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,13 +17,14 @@
         "@patternfly/react-core": "^6.2.0",
         "@patternfly/react-icons": "^5.4.2",
         "@patternfly/react-templates": "^6.2.2",
-        "@perses-dev/core": "^0.51.0",
-        "@perses-dev/dashboards": "^0.51.0",
-        "@perses-dev/plugin-system": "^0.51.0",
-        "@perses-dev/scatter-chart-plugin": "^0.7.0",
-        "@perses-dev/tempo-plugin": "^0.51.0-rc.3",
-        "@perses-dev/trace-table-plugin": "^0.7.0",
-        "@perses-dev/tracing-gantt-chart-plugin": "^0.7.0",
+        "@perses-dev/components": "^0.52.0",
+        "@perses-dev/core": "^0.52.0",
+        "@perses-dev/dashboards": "^0.52.0",
+        "@perses-dev/plugin-system": "^0.52.0",
+        "@perses-dev/scatter-chart-plugin": "^0.8.0",
+        "@perses-dev/tempo-plugin": "^0.53.1",
+        "@perses-dev/trace-table-plugin": "^0.8.1",
+        "@perses-dev/tracing-gantt-chart-plugin": "^0.9.1",
         "copy-webpack-plugin": "^12.0.2",
         "i18next": "^23.10.0",
         "i18next-http-backend": "^2.5.0",
@@ -2649,6 +2650,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
@@ -2663,6 +2680,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
@@ -3924,20 +3957,36 @@
       "license": "MIT"
     },
     "node_modules/@modern-js/node-bundle-require": {
-      "version": "2.67.6",
-      "resolved": "https://registry.npmjs.org/@modern-js/node-bundle-require/-/node-bundle-require-2.67.6.tgz",
-      "integrity": "sha512-rRiDQkrm3kgn0E/GNrcvqo4c71PaUs2R8Xmpv6GUKbEr6lz7VNgfZmAhdAQPtNfRfiBe+1sFLzEcwfEdDo/dTA==",
+      "version": "2.68.2",
+      "resolved": "https://registry.npmjs.org/@modern-js/node-bundle-require/-/node-bundle-require-2.68.2.tgz",
+      "integrity": "sha512-MWk/pYx7KOsp+A/rN0as2ji/Ba8x0m129aqZ3Lj6T6CCTWdz0E/IsamPdTmF9Jnb6whQoBKtWSaLTCQlmCoY0Q==",
       "license": "MIT",
       "dependencies": {
-        "@modern-js/utils": "2.67.6",
+        "@modern-js/utils": "2.68.2",
         "@swc/helpers": "^0.5.17",
-        "esbuild": "0.17.19"
+        "esbuild": "0.25.5"
+      }
+    },
+    "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
       "cpu": [
         "arm"
       ],
@@ -3947,13 +3996,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
       "cpu": [
         "arm64"
       ],
@@ -3963,13 +4012,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
       "cpu": [
         "x64"
       ],
@@ -3979,13 +4028,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
       "cpu": [
         "arm64"
       ],
@@ -3995,13 +4044,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
       "cpu": [
         "x64"
       ],
@@ -4011,13 +4060,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
       "cpu": [
         "arm64"
       ],
@@ -4027,13 +4076,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
       "cpu": [
         "x64"
       ],
@@ -4043,13 +4092,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
       "cpu": [
         "arm"
       ],
@@ -4059,13 +4108,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
       "cpu": [
         "arm64"
       ],
@@ -4075,13 +4124,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
       "cpu": [
         "ia32"
       ],
@@ -4091,13 +4140,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
       "cpu": [
         "loong64"
       ],
@@ -4107,13 +4156,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
       "cpu": [
         "mips64el"
       ],
@@ -4123,13 +4172,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4139,13 +4188,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
       "cpu": [
         "riscv64"
       ],
@@ -4155,13 +4204,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
       "cpu": [
         "s390x"
       ],
@@ -4171,13 +4220,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
       "cpu": [
         "x64"
       ],
@@ -4187,13 +4236,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
       "cpu": [
         "x64"
       ],
@@ -4203,13 +4252,13 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
       "cpu": [
         "x64"
       ],
@@ -4219,13 +4268,13 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
       "cpu": [
         "x64"
       ],
@@ -4235,13 +4284,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
       "cpu": [
         "arm64"
       ],
@@ -4251,13 +4300,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
       "cpu": [
         "ia32"
       ],
@@ -4267,13 +4316,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
       "cpu": [
         "x64"
       ],
@@ -4283,50 +4332,53 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@modern-js/node-bundle-require/node_modules/esbuild": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
+        "@esbuild/aix-ppc64": "0.25.5",
+        "@esbuild/android-arm": "0.25.5",
+        "@esbuild/android-arm64": "0.25.5",
+        "@esbuild/android-x64": "0.25.5",
+        "@esbuild/darwin-arm64": "0.25.5",
+        "@esbuild/darwin-x64": "0.25.5",
+        "@esbuild/freebsd-arm64": "0.25.5",
+        "@esbuild/freebsd-x64": "0.25.5",
+        "@esbuild/linux-arm": "0.25.5",
+        "@esbuild/linux-arm64": "0.25.5",
+        "@esbuild/linux-ia32": "0.25.5",
+        "@esbuild/linux-loong64": "0.25.5",
+        "@esbuild/linux-mips64el": "0.25.5",
+        "@esbuild/linux-ppc64": "0.25.5",
+        "@esbuild/linux-riscv64": "0.25.5",
+        "@esbuild/linux-s390x": "0.25.5",
+        "@esbuild/linux-x64": "0.25.5",
+        "@esbuild/netbsd-arm64": "0.25.5",
+        "@esbuild/netbsd-x64": "0.25.5",
+        "@esbuild/openbsd-arm64": "0.25.5",
+        "@esbuild/openbsd-x64": "0.25.5",
+        "@esbuild/sunos-x64": "0.25.5",
+        "@esbuild/win32-arm64": "0.25.5",
+        "@esbuild/win32-ia32": "0.25.5",
+        "@esbuild/win32-x64": "0.25.5"
       }
     },
     "node_modules/@modern-js/utils": {
-      "version": "2.67.6",
-      "resolved": "https://registry.npmjs.org/@modern-js/utils/-/utils-2.67.6.tgz",
-      "integrity": "sha512-cxY7HsSH0jIN3rlL6RZ0tgzC1tH0gHW++8X6h7sXCNCylhUdbGZI9yTGbpAS8bU7c97NmPaTKg+/ILt00Kju1Q==",
+      "version": "2.68.2",
+      "resolved": "https://registry.npmjs.org/@modern-js/utils/-/utils-2.68.2.tgz",
+      "integrity": "sha512-revom/i/EhKfI0STNLo/AUbv7gY0JY0Ni2gO6P/Z4cTyZZRgd5j90678YB2DGn+LtmSrEWtUphyDH5Jn1RKjgg==",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.17",
@@ -4336,20 +4388,20 @@
       }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.14.3.tgz",
-      "integrity": "sha512-lRkAeNpRdsOFIYx+SSEzsWUZbr2RdfcLA0UbadBaWV3FgeoSd0mef9IO9+KlY1y05anvwOS17VlsX0DeCbvMXg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.19.1.tgz",
+      "integrity": "sha512-D+iFESodr/ohaXjmTOWBSFdjAz/WfN5Y5lIKB5Axh19FBUxvCy6Pj/We7C5JXc8CD9puqxXFOBNysJ7KNB89iw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.14.3",
+        "@module-federation/sdk": "0.19.1",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
     },
-    "node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+    "node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/@module-federation/sdk": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-0JTkYaa4qNLtYGc6ZQQ50BinWh4bAOgT8t17jB/6BqcWiza6fKz647wN0AK+VX3rtl6kvGAjhtqqZtRBc8aeiw==",
       "license": "MIT"
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/semver": {
@@ -4365,14 +4417,14 @@
       }
     },
     "node_modules/@module-federation/cli": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-0.14.3.tgz",
-      "integrity": "sha512-BRR1d+piUSKW5OAuU+ej/zS3pMS4ismea9XHD/DWGJXW/Am7h1pFxRNYAZ8iflLJQ46oqjS/j1ECc5WJmbHlxw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-0.19.1.tgz",
+      "integrity": "sha512-WHEnqGLLtK3jFdAhhW5WMqF5TO4FUfgp6+ujuZLrB1iOnjJXwg/+3F/qjWQtfUPIUCJSAC+58TSKXo8FjNcxPA==",
       "license": "MIT",
       "dependencies": {
-        "@modern-js/node-bundle-require": "2.67.6",
-        "@module-federation/dts-plugin": "0.14.3",
-        "@module-federation/sdk": "0.14.3",
+        "@modern-js/node-bundle-require": "2.68.2",
+        "@module-federation/dts-plugin": "0.19.1",
+        "@module-federation/sdk": "0.19.1",
         "chalk": "3.0.0",
         "commander": "11.1.0"
       },
@@ -4383,38 +4435,11 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@module-federation/cli/node_modules/@module-federation/dts-plugin": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.14.3.tgz",
-      "integrity": "sha512-QiE4wcra6dNo36028cX//QfX0uKF6UeoQoaVIIu06imF4KjCNQD3bE91D6H3DlVVD/UjnIDeUSt9AoGesLzbSA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.14.3",
-        "@module-federation/managers": "0.14.3",
-        "@module-federation/sdk": "0.14.3",
-        "@module-federation/third-party-dts-extractor": "0.14.3",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "^1.8.2",
-        "chalk": "3.0.0",
-        "fs-extra": "9.1.0",
-        "isomorphic-ws": "5.0.0",
-        "koa": "2.16.1",
-        "lodash.clonedeepwith": "4.5.0",
-        "log4js": "6.9.1",
-        "node-schedule": "2.1.1",
-        "rambda": "^9.1.0",
-        "ws": "8.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
-      }
+    "node_modules/@module-federation/cli/node_modules/@module-federation/sdk": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-0JTkYaa4qNLtYGc6ZQQ50BinWh4bAOgT8t17jB/6BqcWiza6fKz647wN0AK+VX3rtl6kvGAjhtqqZtRBc8aeiw==",
+      "license": "MIT"
     },
     "node_modules/@module-federation/cli/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -4492,7 +4517,167 @@
         "node": ">=8"
       }
     },
-    "node_modules/@module-federation/cli/node_modules/ws": {
+    "node_modules/@module-federation/data-prefetch": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.19.1.tgz",
+      "integrity": "sha512-EXtEhYBw5XSHmtLp8Nu0sK2MMkdBtmvWQFfWmLDjPGGTeJHNE+fIHmef9hDbqXra8RpCyyZgwfTCUMZcwAGvzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.19.1",
+        "@module-federation/sdk": "0.19.1",
+        "fs-extra": "9.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/error-codes": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.19.1.tgz",
+      "integrity": "sha512-XtrOfaYPBD9UbdWb7O+gk295/5EFfC2/R6JmhbQmM2mt2axlrwUoy29LAEMSpyMkAD0NfRfQ3HaOsJQiUIy+Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/runtime": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.19.1.tgz",
+      "integrity": "sha512-eSXexdGGPpZnhiWCVfRlVLNWj7gHKp65beC4b8wddTvMBIrxnsdl9ae1ebwcIpbe9gOGDbaXBFtc3r5MH6l6Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.19.1",
+        "@module-federation/runtime-core": "0.19.1",
+        "@module-federation/sdk": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/runtime-core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.19.1.tgz",
+      "integrity": "sha512-NLSlPnIzO2RoF6W1xq/x3t1j7jcglMaPSv2EIVOFvs5/ah7BeJmRhtH494tmjIwV0q+j1QEGGhijHxXZLK1HMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.19.1",
+        "@module-federation/sdk": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/sdk": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-0JTkYaa4qNLtYGc6ZQQ50BinWh4bAOgT8t17jB/6BqcWiza6fKz647wN0AK+VX3rtl6kvGAjhtqqZtRBc8aeiw==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/dts-plugin": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.19.1.tgz",
+      "integrity": "sha512-/MV5gbEsiQiDwPmEq8WS24P/ibDtRwM7ejRKwZ+vWqv11jg75FlxHdzl71CMt5AatoPiUkrsPDQDO1EmKz/NXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.19.1",
+        "@module-federation/managers": "0.19.1",
+        "@module-federation/sdk": "0.19.1",
+        "@module-federation/third-party-dts-extractor": "0.19.1",
+        "adm-zip": "^0.5.10",
+        "ansi-colors": "^4.1.3",
+        "axios": "^1.11.0",
+        "chalk": "3.0.0",
+        "fs-extra": "9.1.0",
+        "isomorphic-ws": "5.0.0",
+        "koa": "3.0.1",
+        "lodash.clonedeepwith": "4.5.0",
+        "log4js": "6.9.1",
+        "node-schedule": "2.1.1",
+        "rambda": "^9.1.0",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/@module-federation/error-codes": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.19.1.tgz",
+      "integrity": "sha512-XtrOfaYPBD9UbdWb7O+gk295/5EFfC2/R6JmhbQmM2mt2axlrwUoy29LAEMSpyMkAD0NfRfQ3HaOsJQiUIy+Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/@module-federation/sdk": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-0JTkYaa4qNLtYGc6ZQQ50BinWh4bAOgT8t17jB/6BqcWiza6fKz647wN0AK+VX3rtl6kvGAjhtqqZtRBc8aeiw==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@module-federation/dts-plugin/node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
@@ -4513,92 +4698,151 @@
         }
       }
     },
-    "node_modules/@module-federation/data-prefetch": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.14.3.tgz",
-      "integrity": "sha512-jGSeo4e32PxTIqPxxwb11oqBXLzygx7fsbV0RXHhy0W1IXDzFObYbHCN95ohxAEh25Hn5jinxBCFn/ltEzQUlA==",
+    "node_modules/@module-federation/enhanced": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.19.1.tgz",
+      "integrity": "sha512-cSNbV5IFZRECpKEdIhIGNW9dNPjyDmSFlPIV0OG7aP4zAmUtz/oizpYtEE5r7hLAGxzWwBnj7zQIIxvmKgrSAQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.14.3",
-        "@module-federation/sdk": "0.14.3",
-        "fs-extra": "9.1.0"
+        "@module-federation/bridge-react-webpack-plugin": "0.19.1",
+        "@module-federation/cli": "0.19.1",
+        "@module-federation/data-prefetch": "0.19.1",
+        "@module-federation/dts-plugin": "0.19.1",
+        "@module-federation/error-codes": "0.19.1",
+        "@module-federation/inject-external-runtime-core-plugin": "0.19.1",
+        "@module-federation/managers": "0.19.1",
+        "@module-federation/manifest": "0.19.1",
+        "@module-federation/rspack": "0.19.1",
+        "@module-federation/runtime-tools": "0.19.1",
+        "@module-federation/sdk": "0.19.1",
+        "btoa": "^1.2.1",
+        "schema-utils": "^4.3.0",
+        "upath": "2.0.1"
+      },
+      "bin": {
+        "mf": "bin/mf.js"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/@module-federation/error-codes": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.19.1.tgz",
+      "integrity": "sha512-XtrOfaYPBD9UbdWb7O+gk295/5EFfC2/R6JmhbQmM2mt2axlrwUoy29LAEMSpyMkAD0NfRfQ3HaOsJQiUIy+Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/enhanced/node_modules/@module-federation/inject-external-runtime-core-plugin": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.19.1.tgz",
+      "integrity": "sha512-yOErRSKR60H4Zyk4nUqsc7u7eLaZ5KX3FXAyKxdGwIJ1B8jJJS+xRiQM8bwRansoF23rv7XWO62K5w/qONiTuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@module-federation/runtime-tools": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/@module-federation/runtime": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.19.1.tgz",
+      "integrity": "sha512-eSXexdGGPpZnhiWCVfRlVLNWj7gHKp65beC4b8wddTvMBIrxnsdl9ae1ebwcIpbe9gOGDbaXBFtc3r5MH6l6Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.19.1",
+        "@module-federation/runtime-core": "0.19.1",
+        "@module-federation/sdk": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/@module-federation/runtime-core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.19.1.tgz",
+      "integrity": "sha512-NLSlPnIzO2RoF6W1xq/x3t1j7jcglMaPSv2EIVOFvs5/ah7BeJmRhtH494tmjIwV0q+j1QEGGhijHxXZLK1HMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.19.1",
+        "@module-federation/sdk": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/@module-federation/runtime-tools": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.19.1.tgz",
+      "integrity": "sha512-WjLZcuP7U5pSQobMEvaMH9pFrvfV3Kk2dfOUNza0tpj6vYtAxk6FU6TQ8WDjqG7yuglyAzq0bVEKVrdIB4Vd9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.19.1",
+        "@module-federation/webpack-bundler-runtime": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/@module-federation/sdk": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-0JTkYaa4qNLtYGc6ZQQ50BinWh4bAOgT8t17jB/6BqcWiza6fKz647wN0AK+VX3rtl6kvGAjhtqqZtRBc8aeiw==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/enhanced/node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.19.1.tgz",
+      "integrity": "sha512-pr9kgwvBoe8tvXELDCqu8ihvLJYwS+cfwJmvk99MTbespzK0nuOepkeRCy2gOpeATDNiWdy/2DJcw34qeAmhJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.19.1",
+        "@module-federation/sdk": "0.19.1"
       }
     },
     "node_modules/@module-federation/error-codes": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.14.3.tgz",
       "integrity": "sha512-sBJ3XKU9g5Up31jFeXPFsD8AgORV7TLO/cCSMuRewSfgYbG/3vSKLJmfHrO6+PvjZSb9VyV2UaF02ojktW65vw==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.14.3.tgz",
-      "integrity": "sha512-OurBx/gDkRPKl9pidefG4EtJeSk8izaj3ZVN/sGGMOXLFeWLK2i0ZSUM/5ogPLj9NPdQC8tTlPalEUsRQ38DoA==",
       "license": "MIT",
-      "peerDependencies": {
-        "@module-federation/runtime-tools": "0.14.3"
-      }
+      "peer": true
     },
     "node_modules/@module-federation/managers": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.14.3.tgz",
-      "integrity": "sha512-uQiLRUvy2yiWm7Xa75y8/He3swW0l2hn8Ef09mvSXhjewwFQMPClQAmZa1UCgNk1F7s/dXDtL9E8vlnX/aZdOQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.19.1.tgz",
+      "integrity": "sha512-bZwiRqc0Cy76xSgKw8dFpVc0tpu6EG+paL0bAtHU5Kj9SBRGyCZ1JQY2W+S8z5tS/7M+gDNl9iIgQim+Kq6isg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.14.3",
+        "@module-federation/sdk": "0.19.1",
         "find-pkg": "2.0.0",
         "fs-extra": "9.1.0"
       }
     },
+    "node_modules/@module-federation/managers/node_modules/@module-federation/sdk": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-0JTkYaa4qNLtYGc6ZQQ50BinWh4bAOgT8t17jB/6BqcWiza6fKz647wN0AK+VX3rtl6kvGAjhtqqZtRBc8aeiw==",
+      "license": "MIT"
+    },
     "node_modules/@module-federation/manifest": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.14.3.tgz",
-      "integrity": "sha512-GsD4PK7JTDOX8g2NyGhsoejhfyP88h6wCaxW4zAq6X91CE9Yu1R/Ec6QHhp9jfXdQlgkoXz1nQRlkbiU7RNTDA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.19.1.tgz",
+      "integrity": "sha512-6QruFQRpedVpHq2JpsYFMrFQvSbqe4QcGjk6zYWQCx+kcUvxYuKwfRzhyJt/Sorqz2rW92I2ckmlHKufCLOmTg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "0.14.3",
-        "@module-federation/managers": "0.14.3",
-        "@module-federation/sdk": "0.14.3",
+        "@module-federation/dts-plugin": "0.19.1",
+        "@module-federation/managers": "0.19.1",
+        "@module-federation/sdk": "0.19.1",
         "chalk": "3.0.0",
         "find-pkg": "2.0.0"
       }
     },
-    "node_modules/@module-federation/manifest/node_modules/@module-federation/dts-plugin": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.14.3.tgz",
-      "integrity": "sha512-QiE4wcra6dNo36028cX//QfX0uKF6UeoQoaVIIu06imF4KjCNQD3bE91D6H3DlVVD/UjnIDeUSt9AoGesLzbSA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.14.3",
-        "@module-federation/managers": "0.14.3",
-        "@module-federation/sdk": "0.14.3",
-        "@module-federation/third-party-dts-extractor": "0.14.3",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "^1.8.2",
-        "chalk": "3.0.0",
-        "fs-extra": "9.1.0",
-        "isomorphic-ws": "5.0.0",
-        "koa": "2.16.1",
-        "lodash.clonedeepwith": "4.5.0",
-        "log4js": "6.9.1",
-        "node-schedule": "2.1.1",
-        "rambda": "^9.1.0",
-        "ws": "8.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
-      }
+    "node_modules/@module-federation/manifest/node_modules/@module-federation/sdk": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-0JTkYaa4qNLtYGc6ZQQ50BinWh4bAOgT8t17jB/6BqcWiza6fKz647wN0AK+VX3rtl6kvGAjhtqqZtRBc8aeiw==",
+      "license": "MIT"
     },
     "node_modules/@module-federation/manifest/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -4667,25 +4911,95 @@
         "node": ">=8"
       }
     },
-    "node_modules/@module-federation/manifest/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+    "node_modules/@module-federation/rspack": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.19.1.tgz",
+      "integrity": "sha512-H/bmdHhK91JIar9juyxdGQkjk5fLwbfugoBwFzxCx0PybwKObs+ZHW7yZ1ZoVBsRkYmvV79R2Squgtn/aGReCA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.19.1",
+        "@module-federation/dts-plugin": "0.19.1",
+        "@module-federation/inject-external-runtime-core-plugin": "0.19.1",
+        "@module-federation/managers": "0.19.1",
+        "@module-federation/manifest": "0.19.1",
+        "@module-federation/runtime-tools": "0.19.1",
+        "@module-federation/sdk": "0.19.1",
+        "btoa": "1.2.1"
       },
       "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
+        "@rspack/core": ">=0.7",
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
       },
       "peerDependenciesMeta": {
-        "bufferutil": {
+        "typescript": {
           "optional": true
         },
-        "utf-8-validate": {
+        "vue-tsc": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@module-federation/rspack/node_modules/@module-federation/error-codes": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.19.1.tgz",
+      "integrity": "sha512-XtrOfaYPBD9UbdWb7O+gk295/5EFfC2/R6JmhbQmM2mt2axlrwUoy29LAEMSpyMkAD0NfRfQ3HaOsJQiUIy+Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/rspack/node_modules/@module-federation/inject-external-runtime-core-plugin": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.19.1.tgz",
+      "integrity": "sha512-yOErRSKR60H4Zyk4nUqsc7u7eLaZ5KX3FXAyKxdGwIJ1B8jJJS+xRiQM8bwRansoF23rv7XWO62K5w/qONiTuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@module-federation/runtime-tools": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/rspack/node_modules/@module-federation/runtime": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.19.1.tgz",
+      "integrity": "sha512-eSXexdGGPpZnhiWCVfRlVLNWj7gHKp65beC4b8wddTvMBIrxnsdl9ae1ebwcIpbe9gOGDbaXBFtc3r5MH6l6Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.19.1",
+        "@module-federation/runtime-core": "0.19.1",
+        "@module-federation/sdk": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/rspack/node_modules/@module-federation/runtime-core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.19.1.tgz",
+      "integrity": "sha512-NLSlPnIzO2RoF6W1xq/x3t1j7jcglMaPSv2EIVOFvs5/ah7BeJmRhtH494tmjIwV0q+j1QEGGhijHxXZLK1HMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.19.1",
+        "@module-federation/sdk": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/rspack/node_modules/@module-federation/runtime-tools": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.19.1.tgz",
+      "integrity": "sha512-WjLZcuP7U5pSQobMEvaMH9pFrvfV3Kk2dfOUNza0tpj6vYtAxk6FU6TQ8WDjqG7yuglyAzq0bVEKVrdIB4Vd9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.19.1",
+        "@module-federation/webpack-bundler-runtime": "0.19.1"
+      }
+    },
+    "node_modules/@module-federation/rspack/node_modules/@module-federation/sdk": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-0JTkYaa4qNLtYGc6ZQQ50BinWh4bAOgT8t17jB/6BqcWiza6fKz647wN0AK+VX3rtl6kvGAjhtqqZtRBc8aeiw==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/rspack/node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.19.1.tgz",
+      "integrity": "sha512-pr9kgwvBoe8tvXELDCqu8ihvLJYwS+cfwJmvk99MTbespzK0nuOepkeRCy2gOpeATDNiWdy/2DJcw34qeAmhJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.19.1",
+        "@module-federation/sdk": "0.19.1"
       }
     },
     "node_modules/@module-federation/runtime": {
@@ -4693,6 +5007,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.14.3.tgz",
       "integrity": "sha512-7ZHpa3teUDVhraYdxQGkfGHzPbjna4LtwbpudgzAxSLLFxLDNanaxCuSeIgSM9c+8sVUNC9kvzUgJEZB0krPJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.14.3",
         "@module-federation/runtime-core": "0.14.3",
@@ -4704,6 +5019,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.14.3.tgz",
       "integrity": "sha512-xMFQXflLVW/AJTWb4soAFP+LB4XuhE7ryiLIX8oTyUoBBgV6U2OPghnFljPjeXbud72O08NYlQ1qsHw1kN/V8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.14.3",
         "@module-federation/sdk": "0.14.3"
@@ -4714,6 +5030,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.14.3.tgz",
       "integrity": "sha512-QBETX7iMYXdSa3JtqFlYU+YkpymxETZqyIIRiqg0gW+XGpH3jgU68yjrme2NBJp7URQi/CFZG8KWtfClk0Pjgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.14.3",
         "@module-federation/webpack-bundler-runtime": "0.14.3"
@@ -4723,12 +5040,13 @@
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.14.3.tgz",
       "integrity": "sha512-THJZMfbXpqjQOLblCQ8jjcBFFXsGRJwUWE9l/Q4SmuCSKMgAwie7yLT0qSGrHmyBYrsUjAuy+xNB4nfKP0pnGw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.14.3.tgz",
-      "integrity": "sha512-XAbUoN5hP9iSnrKGikDIy8CloWCKHRIpe+DWOlq8u7uXoRpAPs/a5K7uegxB27dZUNxSFEfqDeHrpQORNnDqPg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.19.1.tgz",
+      "integrity": "sha512-XBuujPLWgJjljm/QfShtI0pErqRL28iiJ7AsUpFsNbSRJiBlcXTDPKqFWiZXmp/lGmJigLV2wDgyK0cyKqoWcg==",
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
@@ -4758,6 +5076,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.14.3.tgz",
       "integrity": "sha512-hIyJFu34P7bY2NeMIUHAS/mYUHEY71VTAsN0A0AqEJFSVPszheopu9VdXq0VDLrP9KQfuXT8SDxeYeJXyj0mgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.14.3",
         "@module-federation/sdk": "0.14.3"
@@ -5401,9 +5720,9 @@
       "license": "MIT"
     },
     "node_modules/@perses-dev/components": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.51.0.tgz",
-      "integrity": "sha512-tcBxv9tEYT9P41mUg8CBMj4tL5NXOP1sVSn9eJYG7XKzygH1BFuvHcsOsylyTH5F+Xm5R78llRX+TuEAWKRIng==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.52.0.tgz",
+      "integrity": "sha512-SPWHI/DKdUFiP4b3tP1+MgU+N4Y2ZGMWIXN7Fd+qRvU0vU0J7RWTjvszKrznLBboo1pPZQpoFE+Y6V3A2TFgxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
@@ -5411,7 +5730,7 @@
         "@codemirror/lang-json": "^6.0.1",
         "@fontsource/lato": "^4.5.10",
         "@mui/x-date-pickers": "^7.23.1",
-        "@perses-dev/core": "0.51.0",
+        "@perses-dev/core": "0.52.0",
         "@tanstack/react-table": "^8.20.5",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^4.1.0",
@@ -5434,9 +5753,9 @@
       }
     },
     "node_modules/@perses-dev/core": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.51.0.tgz",
-      "integrity": "sha512-RY72PRVTVEURCWWgUO8KInes0W6lwI5YauLjwpn9HjwxA+JocoHmm723byOAyE145f4sqeZA+MWlYVYj7ymzLg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/core/-/core-0.52.0.tgz",
+      "integrity": "sha512-dtaNSgVx4YH3kmQLdHyFun+C2WH1Fp85lLKA2ZEyAMX5hQZ3GwL1cusb2J51R4SPHRJ79YCtkbwD7dYnJBnrsw==",
       "license": "Apache-2.0",
       "dependencies": {
         "date-fns": "^4.1.0",
@@ -5451,14 +5770,14 @@
       }
     },
     "node_modules/@perses-dev/dashboards": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.51.0.tgz",
-      "integrity": "sha512-kzHfVq0g1IT2JKobNfx2/9L6TF2uT1wbjSEcNn7RjCFk1RV0uAMpoV5Estxtf6ROn3pTZhrFtLxFFcfnWX/ezw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.52.0.tgz",
+      "integrity": "sha512-InOalnIIUJxqOaJI8t1+FPOXf0OhQ0+BczNU+CP28THUpIPAxliOZUzvLGQ/OqEFepnapb+RlOYCNKF04Cdcpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@perses-dev/components": "0.51.0",
-        "@perses-dev/core": "0.51.0",
-        "@perses-dev/plugin-system": "0.51.0",
+        "@perses-dev/components": "0.52.0",
+        "@perses-dev/core": "0.52.0",
+        "@perses-dev/plugin-system": "0.52.0",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^4.1.0",
         "immer": "^10.1.1",
@@ -5467,7 +5786,7 @@
         "react-hook-form": "^7.46.1",
         "react-intersection-observer": "^9.4.0",
         "use-immer": "^0.11.0",
-        "use-query-params": "^2.1.1",
+        "use-query-params": "^2.2.1",
         "use-resize-observer": "^9.0.0",
         "yaml": "^2.7.0",
         "zustand": "^4.3.3"
@@ -5480,29 +5799,30 @@
       }
     },
     "node_modules/@perses-dev/explore": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.51.0.tgz",
-      "integrity": "sha512-1Vk8itkIN9rEk3+xP/5Xyo1Cp4O6kfao975dsQmBQsFGlPF+vJQPMIBXGTYnbS/cdNSbQrnM5IURrjI/X1YZxg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.52.0.tgz",
+      "integrity": "sha512-J5ur8+LhRasOf57E5txGFrEurYC5wihkk019BHgPnBxPlusxYxuwdp/s25PGtRP/pXFHxQejogIS9GnyhX+xcA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
-        "@perses-dev/components": "0.51.0",
-        "@perses-dev/core": "0.51.0",
-        "@perses-dev/dashboards": "0.51.0",
-        "@perses-dev/plugin-system": "0.51.0",
+        "@perses-dev/components": "0.52.0",
+        "@perses-dev/core": "0.52.0",
+        "@perses-dev/dashboards": "0.52.0",
+        "@perses-dev/plugin-system": "0.52.0",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^4.1.0",
         "immer": "^10.1.1",
         "mdi-material-ui": "^7.9.2",
-        "qs": "^6.13.0",
+        "qs": "^6.14.0",
         "react-grid-layout": "^1.3.4",
         "react-hook-form": "^7.46.1",
         "react-intersection-observer": "^9.4.0",
         "react-virtuoso": "^4.12.2",
         "use-immer": "^0.11.0",
-        "use-query-params": "^2.1.1",
+        "use-query-params": "^2.2.1",
         "use-resize-observer": "^9.0.0",
+        "zod": "^3.21.4",
         "zustand": "^4.3.3"
       },
       "peerDependencies": {
@@ -5513,20 +5833,20 @@
       }
     },
     "node_modules/@perses-dev/plugin-system": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.51.0.tgz",
-      "integrity": "sha512-4zhRKfcmIUedxoZnwhWLvx0zzrSfTdAkA7C2WUow0HJ8LCPTI/D4uB33oW3XAi2lFIJxcW9mpUBAK4FtTSjizg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.52.0.tgz",
+      "integrity": "sha512-6wNTZQwlcpX3sCc/Fq1N9/waIh9YGmniCngkqnAw9zhu04UVNKT1ESFAg7IGjJNnIg70Ezx8L7lrI5gSdtjiMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@module-federation/enhanced": "^0.14.3",
-        "@perses-dev/components": "0.51.0",
-        "@perses-dev/core": "0.51.0",
+        "@module-federation/enhanced": "^0.19.1",
+        "@perses-dev/components": "0.52.0",
+        "@perses-dev/core": "0.52.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "immer": "^10.1.1",
         "react-hook-form": "^7.46.1",
         "use-immer": "^0.11.0",
-        "use-query-params": "^2.1.2",
+        "use-query-params": "^2.2.1",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
@@ -5536,201 +5856,10 @@
         "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
-    "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/dts-plugin": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.14.3.tgz",
-      "integrity": "sha512-QiE4wcra6dNo36028cX//QfX0uKF6UeoQoaVIIu06imF4KjCNQD3bE91D6H3DlVVD/UjnIDeUSt9AoGesLzbSA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.14.3",
-        "@module-federation/managers": "0.14.3",
-        "@module-federation/sdk": "0.14.3",
-        "@module-federation/third-party-dts-extractor": "0.14.3",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "^1.8.2",
-        "chalk": "3.0.0",
-        "fs-extra": "9.1.0",
-        "isomorphic-ws": "5.0.0",
-        "koa": "2.16.1",
-        "lodash.clonedeepwith": "4.5.0",
-        "log4js": "6.9.1",
-        "node-schedule": "2.1.1",
-        "rambda": "^9.1.0",
-        "ws": "8.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/enhanced": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.14.3.tgz",
-      "integrity": "sha512-9R15Sm+hCn9yNtOTEwN1cHppC/sMb/LfoTcA94jLMB6lcyYz+uNzc5JliyrMawU1/guOQiBZkUVL/thB8DHURw==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.14.3",
-        "@module-federation/cli": "0.14.3",
-        "@module-federation/data-prefetch": "0.14.3",
-        "@module-federation/dts-plugin": "0.14.3",
-        "@module-federation/error-codes": "0.14.3",
-        "@module-federation/inject-external-runtime-core-plugin": "0.14.3",
-        "@module-federation/managers": "0.14.3",
-        "@module-federation/manifest": "0.14.3",
-        "@module-federation/rspack": "0.14.3",
-        "@module-federation/runtime-tools": "0.14.3",
-        "@module-federation/sdk": "0.14.3",
-        "btoa": "^1.2.1",
-        "schema-utils": "^4.3.0",
-        "upath": "2.0.1"
-      },
-      "bin": {
-        "mf": "bin/mf.js"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "vue-tsc": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/@module-federation/rspack": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.14.3.tgz",
-      "integrity": "sha512-s02E7n9CnR+IMraYwGqfSU2uScENPU+TUd45YteMKxcKOIqNRALtGMn/YT24bbnj+wZ/jhvzr7Rbcx9AkaxKhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.14.3",
-        "@module-federation/dts-plugin": "0.14.3",
-        "@module-federation/inject-external-runtime-core-plugin": "0.14.3",
-        "@module-federation/managers": "0.14.3",
-        "@module-federation/manifest": "0.14.3",
-        "@module-federation/runtime-tools": "0.14.3",
-        "@module-federation/sdk": "0.14.3",
-        "btoa": "1.2.1"
-      },
-      "peerDependencies": {
-        "@rspack/core": ">=0.7",
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@perses-dev/plugin-system/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@perses-dev/scatter-chart-plugin": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/scatter-chart-plugin/-/scatter-chart-plugin-0.7.0.tgz",
-      "integrity": "sha512-l9z1qSSqqhniYgbncrbv3PMkURXHJwBPJhycjlQdkHtoPdSLw6n4BlcbJyqJXVBjubnVnENGkhcJcAbHSUskHQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/scatter-chart-plugin/-/scatter-chart-plugin-0.8.0.tgz",
+      "integrity": "sha512-1tDnpsQdu8XuWsKDUYlrReXY8o9zhylHYyPZTQ3gs8LVVEgOXWDqBUgjxzkAt6mNoaCL8TuJk3g2kpAJlMxVKw==",
       "dependencies": {
         "react-virtuoso": "^4.12.2"
       },
@@ -5738,9 +5867,9 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-rc.1",
-        "@perses-dev/core": "^0.51.0-rc.1",
-        "@perses-dev/plugin-system": "^0.51.0-rc.1",
+        "@perses-dev/components": "^0.52.0-beta.5",
+        "@perses-dev/core": "^0.52.0-beta.5",
+        "@perses-dev/plugin-system": "^0.52.0-beta.5",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -5751,9 +5880,9 @@
       }
     },
     "node_modules/@perses-dev/tempo-plugin": {
-      "version": "0.51.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@perses-dev/tempo-plugin/-/tempo-plugin-0.51.0-rc.3.tgz",
-      "integrity": "sha512-mBZ95PiVrxawNDjqsfatMJywqwYSk+AjCpwTeS+V18dSf+epPvc2IqxIEST/TMReoe/KfJEKr0atzXniJUsEUw==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/tempo-plugin/-/tempo-plugin-0.53.1.tgz",
+      "integrity": "sha512-dx0vqVpq61czGldBECkMealfI67dq33wNwG7Tp14DyN0Jk1exghaSdBiMwinNwyD4B2YxBN3mcP2bmAqJE29mA==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
         "@grafana/lezer-traceql": "^0.0.20",
@@ -5763,11 +5892,11 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-rc.1",
-        "@perses-dev/core": "^0.51.0-rc.1",
-        "@perses-dev/dashboards": "^0.51.0-rc.1",
-        "@perses-dev/explore": "^0.51.0-rc.1",
-        "@perses-dev/plugin-system": "^0.51.0-rc.1",
+        "@perses-dev/components": "^0.52.0-beta.5",
+        "@perses-dev/core": "^0.52.0-beta.5",
+        "@perses-dev/dashboards": "^0.52.0-beta.5",
+        "@perses-dev/explore": "^0.52.0-beta.5",
+        "@perses-dev/plugin-system": "^0.52.0-beta.5",
         "@tanstack/react-query": "^4.39.1",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^4.1.0",
@@ -5791,9 +5920,9 @@
       }
     },
     "node_modules/@perses-dev/trace-table-plugin": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/trace-table-plugin/-/trace-table-plugin-0.7.0.tgz",
-      "integrity": "sha512-n+I0b9YOqhqXNF1mrR2cc6K7hoiBtYyqS5CN8WaNH5qpgE2MdRZAjfZz3Dp9024gOZl4VDwsb8LdNSGUCyD7Nw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/trace-table-plugin/-/trace-table-plugin-0.8.1.tgz",
+      "integrity": "sha512-tOs+YGl3SirWYRyxE/rPtfvtCODvLsQxWhjiSLop3fPT9Ue9CKwLou653o6S2l9p17FHuRKFfqiNhJLrPQ8JMQ==",
       "dependencies": {
         "@mui/x-data-grid": "^7.20.0"
       },
@@ -5801,23 +5930,22 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-rc.1",
-        "@perses-dev/core": "^0.51.0-rc.1",
-        "@perses-dev/plugin-system": "^0.51.0-rc.1",
+        "@perses-dev/components": "^0.52.0-beta.5",
+        "@perses-dev/core": "^0.52.0-beta.5",
+        "@perses-dev/plugin-system": "^0.52.0-beta.5",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
         "lodash": "^4.17.21",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0",
-        "react-router-dom": "^5 || ^6 || ^7",
         "use-resize-observer": "^9.0.0"
       }
     },
     "node_modules/@perses-dev/tracing-gantt-chart-plugin": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/tracing-gantt-chart-plugin/-/tracing-gantt-chart-plugin-0.7.0.tgz",
-      "integrity": "sha512-eGdMpbna0fnm1EvwUWxU3ByCBSANJisAaDK5Zj4xuNbUPGzO206MpDkIw9VJMzx/ENIyGjg3YatRrWk/OFGK+g==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/tracing-gantt-chart-plugin/-/tracing-gantt-chart-plugin-0.9.1.tgz",
+      "integrity": "sha512-xqh8OIonk18YtSB3YuT77XD1UeG6YGp5jxSINqoysNLO/vKwqmmiF7fAtPwHy7yLNGS3znjIsFi90r27rYssfw==",
       "dependencies": {
         "color-hash": "^2.0.2"
       },
@@ -5825,16 +5953,15 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.51.0-rc.1",
-        "@perses-dev/core": "^0.51.0-rc.1",
-        "@perses-dev/plugin-system": "^0.51.0-rc.1",
+        "@perses-dev/components": "^0.52.0-beta.5",
+        "@perses-dev/core": "^0.52.0-beta.5",
+        "@perses-dev/plugin-system": "^0.52.0-beta.5",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
         "lodash": "^4.17.21",
         "react": "^17.0.2 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0",
-        "react-router-dom": "^5 || ^6 || ^7",
         "use-resize-observer": "^9.0.0"
       }
     },
@@ -6909,6 +7036,12 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -8266,20 +8399,20 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -9113,19 +9246,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/cache-content-type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
-      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^2.1.18",
-        "ylru": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/cachedir": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
@@ -9626,7 +9746,9 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -11544,7 +11666,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -14235,7 +14356,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -14996,6 +15116,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15197,6 +15318,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17705,37 +17827,32 @@
       "license": "MIT"
     },
     "node_modules/koa": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.0.1.tgz",
+      "integrity": "sha512-oDxVkRwPOHhGlxKIDiDB2h+/l05QPtefD7nSqRgDfZt8P+QVYFWjfeK8jANf5O2YXjk8egd7KntvXKYx82wOag==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "^1.3.5",
-        "cache-content-type": "^1.0.0",
-        "content-disposition": "~0.5.2",
-        "content-type": "^1.0.4",
-        "cookies": "~0.9.0",
-        "debug": "^4.3.2",
+        "accepts": "^1.3.8",
+        "content-disposition": "~0.5.4",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
         "delegates": "^1.0.0",
-        "depd": "^2.0.0",
-        "destroy": "^1.0.4",
-        "encodeurl": "^1.0.2",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "fresh": "~0.5.2",
-        "http-assert": "^1.3.0",
-        "http-errors": "^1.6.3",
-        "is-generator-function": "^1.0.7",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
         "koa-compose": "^4.1.0",
-        "koa-convert": "^2.0.0",
-        "on-finished": "^2.3.0",
-        "only": "~0.0.2",
-        "parseurl": "^1.3.2",
-        "statuses": "^1.5.0",
-        "type-is": "^1.6.16",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
         "vary": "^1.1.2"
       },
       "engines": {
-        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+        "node": ">= 18"
       }
     },
     "node_modules/koa-compose": {
@@ -17744,58 +17861,46 @@
       "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
       "license": "MIT"
     },
-    "node_modules/koa-convert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
-      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
-      "license": "MIT",
-      "dependencies": {
-        "co": "^4.6.0",
-        "koa-compose": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/koa/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+    "node_modules/koa/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/koa/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "license": "MIT",
       "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
+        "mime-db": "^1.54.0"
       },
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/koa/node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+    "node_modules/koa/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/koa/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -18519,6 +18624,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -19814,11 +19920,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/only": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="
     },
     "node_modules/open": {
       "version": "8.4.2",
@@ -23454,12 +23555,10 @@
       "license": "Unlicense"
     },
     "node_modules/rslog": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rslog/-/rslog-1.2.3.tgz",
-      "integrity": "sha512-antALPJaKBRPBU1X2q9t085K4htWDOOv/K1qhTUk7h0l1ePU/KbDqKJn19eKP0dk7PqMioeA0+fu3gyPXCsXxQ==",
-      "engines": {
-        "node": ">=14.17.6"
-      }
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/rslog/-/rslog-1.2.11.tgz",
+      "integrity": "sha512-YgMMzQf6lL9q4rD9WS/lpPWxVNJ1ttY9+dOXJ0+7vJrKCAOT4GH0EiRnBi9mKOitcHiOwjqJPV1n/HRqqgZmOQ==",
+      "license": "MIT"
     },
     "node_modules/rsvp": {
       "version": "4.8.5",
@@ -23585,6 +23684,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -24393,7 +24493,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -26507,6 +26606,7 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -28631,15 +28731,6 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/ylru": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
-      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/yn": {

--- a/web/package.json
+++ b/web/package.json
@@ -68,7 +68,7 @@
     "description": "This plugin adds a distributed tracing UI to the Openshift console.",
     "exposedModules": {
       "TracesPage": "./pages/TracesPage/TracesPage",
-      "TraceDetailPage": "./pages/TraceDetailPage"
+      "TraceDetailPage": "./pages/TraceDetailPage/TraceDetailPage"
     },
     "dependencies": {
       "@console/pluginAPI": "*"
@@ -83,13 +83,14 @@
     "@patternfly/react-core": "^6.2.0",
     "@patternfly/react-icons": "^5.4.2",
     "@patternfly/react-templates": "^6.2.2",
-    "@perses-dev/core": "^0.51.0",
-    "@perses-dev/dashboards": "^0.51.0",
-    "@perses-dev/plugin-system": "^0.51.0",
-    "@perses-dev/scatter-chart-plugin": "^0.7.0",
-    "@perses-dev/tempo-plugin": "^0.51.0-rc.3",
-    "@perses-dev/trace-table-plugin": "^0.7.0",
-    "@perses-dev/tracing-gantt-chart-plugin": "^0.7.0",
+    "@perses-dev/components": "^0.52.0",
+    "@perses-dev/core": "^0.52.0",
+    "@perses-dev/dashboards": "^0.52.0",
+    "@perses-dev/plugin-system": "^0.52.0",
+    "@perses-dev/scatter-chart-plugin": "^0.8.0",
+    "@perses-dev/tempo-plugin": "^0.53.1",
+    "@perses-dev/trace-table-plugin": "^0.8.1",
+    "@perses-dev/tracing-gantt-chart-plugin": "^0.9.1",
     "copy-webpack-plugin": "^12.0.2",
     "i18next": "^23.10.0",
     "i18next-http-backend": "^2.5.0",

--- a/web/src/components/console/utils/usePatternFlyTheme.ts
+++ b/web/src/components/console/utils/usePatternFlyTheme.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-const PF_THEME_DARK_CLASS = 'pf-v5-theme-dark';
-const PF_THEME_DARK_CLASS_LEGACY = 'pf-theme-dark'; // legacy class name needed to support PF4
+// the unversioned class name is required for PF4
+const PF_THEME_DARK_CLASSES = ['pf-v6-theme-dark', 'pf-v5-theme-dark', 'pf-theme-dark'];
 
 /**
  * The @openshift-console/dynamic-plugin-sdk package does not expose the theme setting of the user preferences,
@@ -9,8 +9,10 @@ const PF_THEME_DARK_CLASS_LEGACY = 'pf-theme-dark'; // legacy class name needed 
  */
 function getTheme(): 'light' | 'dark' {
   const classList = document.documentElement.classList;
-  if (classList.contains(PF_THEME_DARK_CLASS) || classList.contains(PF_THEME_DARK_CLASS_LEGACY)) {
-    return 'dark';
+  for (const className of PF_THEME_DARK_CLASSES) {
+    if (classList.contains(className)) {
+      return 'dark';
+    }
   }
   return 'light';
 }

--- a/web/src/links.ts
+++ b/web/src/links.ts
@@ -1,6 +1,39 @@
 // Note: this file must be kept in sync with the route definitions in console-extensions.json
 
-export function linkToTraceDetailPage(traceId: string) {
+export function linkToTrace() {
   // by capturing the entire URL search params, we can provide a breadcrumb to the previous page with the Tempo instance and query filled out
-  return `/observe/traces/${traceId}?${new URLSearchParams(window.location.search).toString()}`;
+  const params = new URLSearchParams(window.location.search);
+  const queryString = params.toString();
+
+  // ${...} will be replaced by Perses, it is not a JavaScript template string
+  return '/observe/traces/${traceId}?' + queryString;
 }
+
+export function linkToSpan() {
+  // by capturing the entire URL search params, we can provide a breadcrumb to the previous page with the Tempo instance and query filled out
+  const params = new URLSearchParams(window.location.search);
+  params.set('selectSpan', 'SPANID');
+
+  // add ${...} syntax after the URL is URL-encoded, because the characters ${} must not be URL-encoded
+  const queryString = params.toString().replace('SPANID', '${spanId}');
+
+  // ${...} will be replaced by Perses, it is not a JavaScript template string
+  return '/observe/traces/${traceId}?' + queryString;
+}
+
+// ${...} will be replaced by Perses, it is not a JavaScript template string
+export const spanAttributeLinks = [
+  {
+    name: 'k8s.namespace.name',
+    link: '/k8s/cluster/namespaces/${k8s_namespace_name:percentencode}',
+  },
+  { name: 'k8s.node.name', link: '/k8s/cluster/nodes/${k8s_node_name:percentencode}' },
+  {
+    name: 'k8s.deployment.name',
+    link: '/k8s/ns/${k8s_namespace_name:percentencode}/deployments/${k8s_deployment_name:percentencode}',
+  },
+  {
+    name: 'k8s.pod.name',
+    link: '/k8s/ns/${k8s_namespace_name:percentencode}/pods/${k8s_pod_name:percentencode}',
+  },
+];

--- a/web/src/pages/TraceDetailPage/TraceDetailPage.css
+++ b/web/src/pages/TraceDetailPage/TraceDetailPage.css
@@ -1,0 +1,34 @@
+.dt-plugin-perses-panel {
+  & > .MuiPaper-root {
+    /* in MUI dark mode, the Paper component has a dark blue background */
+    background-color: inherit;
+  }
+}
+
+.dt-plugin-gantt-chart {
+  height: 100%;
+
+  & > .MuiCard-root {
+    /* Remove panel border */
+    border: none;
+
+    /* Remove panel title, header padding and line between header and content */
+    & > .MuiCardHeader-root {
+      padding: 0;
+      border: none;
+
+      .MuiTypography-root {
+        display: none;
+      }
+    }
+
+    /* Perses panel components are usually in a panel wrapper with a border and 12px padding; remove this padding here. */
+    & > .MuiCardContent-root > .MuiBox-root {
+      padding: 0;
+    }
+  }
+
+  .MuiListItemText-primary {
+    font-weight: var(--pf-t--global--font--weight--body--bold);
+  }
+}

--- a/web/src/pages/TraceDetailPage/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage/TraceDetailPage.tsx
@@ -6,15 +6,16 @@ import { Link, useLocation, useParams } from 'react-router-dom-v5-compat';
 import {
   PersesDashboardWrapper,
   PersesTempoDatasourceWrapper,
+  PersesTracePanelWrapper,
   PersesWrapper,
-  PersesPanelPluginWrapper,
-} from '../components/PersesWrapper';
-import { otlpcommonv1 } from '@perses-dev/core';
+} from '../../components/PersesWrapper';
 import { useDataQueries } from '@perses-dev/plugin-system';
-import { useTempoInstance } from '../hooks/useTempoInstance';
-import { TracingApp } from '../TracingApp';
+import { useTempoInstance } from '../../hooks/useTempoInstance';
+import { TracingApp } from '../../TracingApp';
 import { memo } from 'react';
-import { TracingGanttChart } from '@perses-dev/tracing-gantt-chart-plugin';
+import { linkToSpan, linkToTrace, spanAttributeLinks } from '../../links';
+import { StringParam, useQueryParam } from 'use-query-params';
+import './TraceDetailPage.css';
 
 function TraceDetailPage() {
   return (
@@ -35,6 +36,7 @@ function TraceDetailPageBody() {
   const { traceId } = useParams();
   const [tempo] = useTempoInstance();
   const location = useLocation();
+  const [selectedSpanId] = useQueryParam('selectSpan', StringParam);
 
   return (
     <PersesTempoDatasourceWrapper
@@ -51,12 +53,34 @@ function TraceDetailPageBody() {
         <PageTitle />
         <Divider className="pf-v6-u-mt-md" />
       </PageSection>
-      <PageSection isFilled hasBodyWrapper={false}>
-        <PersesPanelPluginWrapper
-          plugin={TracingGanttChart}
-          spec={{ visual: { palette: { mode: 'categorical' } } }}
-          attributeLinks={attributeLinks}
-        />
+      <PageSection isFilled hasBodyWrapper={false} style={{ paddingTop: 0 }}>
+        <div className="dt-plugin-perses-panel dt-plugin-gantt-chart">
+          <PersesTracePanelWrapper
+            panelOptions={{ showIcons: 'always' }}
+            definition={{
+              kind: 'Panel',
+              spec: {
+                display: { name: `Trace ${traceId}` },
+                plugin: {
+                  kind: 'TracingGanttChart',
+                  spec: {
+                    visual: {
+                      palette: {
+                        mode: 'categorical',
+                      },
+                    },
+                    links: {
+                      trace: linkToTrace(),
+                      span: linkToSpan(),
+                      attributes: spanAttributeLinks,
+                    },
+                    selectedSpanId,
+                  },
+                },
+              },
+            }}
+          />
+        </div>
       </PageSection>
     </PersesTempoDatasourceWrapper>
   );
@@ -101,17 +125,3 @@ function useTraceName(): string {
   // return traceId if span is not loaded or root span is not found
   return traceId ?? '';
 }
-
-const sval = (val?: otlpcommonv1.AnyValue) =>
-  val && 'stringValue' in val ? encodeURIComponent(val.stringValue) : '';
-
-const attributeLinks: Record<string, (attrs: Record<string, otlpcommonv1.AnyValue>) => string> = {
-  'k8s.namespace.name': (attrs) => `/k8s/cluster/namespaces/${sval(attrs['k8s.namespace.name'])}`,
-  'k8s.node.name': (attrs) => `/k8s/cluster/nodes/${sval(attrs['k8s.node.name'])}`,
-  'k8s.deployment.name': (attrs) =>
-    `/k8s/ns/${sval(attrs['k8s.namespace.name'])}/deployments/${sval(
-      attrs['k8s.deployment.name'],
-    )}`,
-  'k8s.pod.name': (attrs) =>
-    `/k8s/ns/${sval(attrs['k8s.namespace.name'])}/pods/${sval(attrs['k8s.pod.name'])}`,
-};

--- a/web/src/pages/TracesPage/ScatterPlot.tsx
+++ b/web/src/pages/TracesPage/ScatterPlot.tsx
@@ -1,37 +1,22 @@
 import React, { useState } from 'react';
-import {
-  Bullseye,
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  Flex,
-  FlexItem,
-} from '@patternfly/react-core';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { PersesPanelPluginWrapper } from '../../components/PersesWrapper';
+import { PersesPanelPluginWrapper, usePersesTraceData } from '../../components/PersesWrapper';
 import { ExpandIcon, CompressIcon } from '@patternfly/react-icons';
 import { useRefWidth } from '../../components/console/utils/ref-width-hook';
-import { useNavigate } from 'react-router-dom-v5-compat';
-import { linkToTraceDetailPage } from '../../links';
+import { linkToTrace } from '../../links';
 import { ScatterChart } from '@perses-dev/scatter-chart-plugin';
 
 export function ScatterPlot() {
   const { t } = useTranslation('plugin__distributed-tracing-console-plugin');
-  const navigate = useNavigate();
   const [isVisible, setVisible] = useState(true);
   const [ref, width] = useRefWidth();
+  const { loading, hasTraceData } = usePersesTraceData();
 
-  const clickHandler = (data: { traceId: string }) => {
-    navigate(linkToTraceDetailPage(data.traceId));
-  };
-
-  const noResults = (
-    <Bullseye>
-      <EmptyState>
-        <EmptyStateBody>{t('No datapoints found.')}</EmptyStateBody>
-      </EmptyState>
-    </Bullseye>
-  );
+  if (!loading && !hasTraceData) {
+    // the trace table already shows a custom empty state
+    return null;
+  }
 
   return (
     <div>
@@ -64,13 +49,13 @@ export function ScatterPlot() {
         >
           <PersesPanelPluginWrapper
             plugin={ScatterChart}
-            noResults={noResults}
             contentDimensions={{
               width,
               height: 200,
             }}
-            spec={{}}
-            onClick={clickHandler}
+            spec={{
+              link: linkToTrace(),
+            }}
           />
         </div>
       )}

--- a/web/src/pages/TracesPage/Toolbar/Filter/traceql.test.ts
+++ b/web/src/pages/TracesPage/Toolbar/Filter/traceql.test.ts
@@ -56,6 +56,19 @@ describe('TraceQL query', () => {
         ],
       },
     },
+    {
+      query: '{ name = "service \\\\ \\" end" && span.http.route="/some/regex \\\\ \\" end" }',
+      expected: {
+        serviceName: [],
+        spanName: ['service \\ " end'],
+        namespace: [],
+        status: [],
+        spanDuration: {},
+        traceDuration: {},
+        // custom matcher values are not escaped
+        customMatchers: ['span.http.route="/some/regex \\\\ \\" end"'],
+      },
+    },
   ])('parse $query', ({ query, expected }) => {
     const filter = traceQLToFilter(query);
     expect(filter).toEqual(expected);

--- a/web/src/pages/TracesPage/Toolbar/Filter/traceql_from_filter.ts
+++ b/web/src/pages/TracesPage/Toolbar/Filter/traceql_from_filter.ts
@@ -18,7 +18,7 @@ export function filterToTraceQL(filter: Filter) {
 }
 
 function escape(q: string) {
-  return q.replace(/"/g, '\\"');
+  return q.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 }
 
 function stringMatcher(attribute: string, values: string[]) {

--- a/web/src/pages/TracesPage/Toolbar/Filter/traceql_to_filter.ts
+++ b/web/src/pages/TracesPage/Toolbar/Filter/traceql_to_filter.ts
@@ -73,7 +73,7 @@ function parseQuery(query: string) {
 }
 
 function unescape(q: string) {
-  return q.replace(/\\"/g, '"');
+  return q.replaceAll('\\"', '"').replaceAll('\\\\', '\\');
 }
 
 function reverseStringMatcher(matches?: Matcher[]) {

--- a/web/src/pages/TracesPage/TraceTable.css
+++ b/web/src/pages/TracesPage/TraceTable.css
@@ -1,6 +1,9 @@
 .dt-plugin-trace-table {
+  /** min height, required for loading state */
+  min-height: 280px;
+
   /* Perses panel components are usually in a panel wrapper with a border and 12px padding; remove this padding here. */
-  &:first-child {
+  & > .MuiBox-root {
     padding: 0;
   }
 

--- a/web/src/pages/TracesPage/TraceTable.tsx
+++ b/web/src/pages/TracesPage/TraceTable.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { linkToTraceDetailPage } from '../../links';
+import { linkToTrace } from '../../links';
 import './TraceTable.css';
 
 interface TraceTableProps {
@@ -40,13 +40,13 @@ export function TraceTable({ setQuery }: TraceTableProps) {
       <PersesPanelPluginWrapper
         plugin={PersesTraceTable}
         noResults={noResults}
-        spec={{ visual: { palette: { mode: 'categorical' } } }}
-        traceLink={traceDetailLink}
+        spec={{
+          visual: { palette: { mode: 'categorical' } },
+          links: {
+            trace: linkToTrace(),
+          },
+        }}
       />
     </div>
   );
-}
-
-export function traceDetailLink({ traceId }: { traceId: string }) {
-  return linkToTraceDetailPage(traceId);
 }


### PR DESCRIPTION
Upgrade Perses to v0.52.0-rc.1, with the following new features:

* span links, permalink for selecting a span (https://issues.redhat.com/browse/TRACING-5390)
* button to download trace as OTLP/JSON (https://issues.redhat.com/browse/TRACING-5578)
* show trace id and span id in gantt chart (https://issues.redhat.com/browse/OU-873)
* add span timestamp and duration (https://issues.redhat.com/browse/OU-926)
* fix quoting in TraceQL auto-completion, support backticks (https://issues.redhat.com/browse/COO-1175)

### Trace ID, Span ID, Timings
<img width="3190" height="1174" alt="image" src="https://github.com/user-attachments/assets/159d6303-24c6-4bb4-9a34-330ef8d70d4f" />

### Span Links
<img width="3198" height="1254" alt="image" src="https://github.com/user-attachments/assets/f78c5471-22f4-4ae3-9bf0-d3fcc1e40635" />

### Escaped TraceQL auto-complete
<img width="1424" height="160" alt="image" src="https://github.com/user-attachments/assets/028250dc-85d0-480f-8a43-50e23f355db0" />
