### PR TITLE
NO-JIRA: [release-coo-ocp-4.15] fix: wire dynamic TLS cert reload and add cert-rotation tests

### DIFF
--- a/pkg/server.go
+++ b/pkg/server.go
@@ -123,8 +123,16 @@ func Start(cfg *Config) {
 			logrus.WithError(err).Fatal("invalid certificate/key files")
 		}
 
+		// Wire GetConfigForClient so every TLS handshake uses the dynamically
+		// reloaded cert instead of the static cert loaded by ListenAndServeTLS.
+		tlsConfig.GetConfigForClient = ctrl.GetConfigForClient
+		// Notify the controller whenever the cert/key files change on disk.
+		certKeyPair.AddListener(ctrl)
+
 		ctx := context.Background()
 		go ctrl.Run(1, ctx.Done())
+		// Start the file watcher that detects cert rotation and notifies the controller.
+		go certKeyPair.Run(ctx, 1)
 	}
 
 	httpServer := &http.Server{

--- a/pkg/server_test.go
+++ b/pkg/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -16,6 +17,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -465,8 +467,112 @@ func TestSecureServerCipherSuites(t *testing.T) {
 	require.Error(t, err, "Client with non-matching cipher suite should be rejected")
 }
 
+// TestSecureServerCertRotation verifies that the server dynamically reloads its
+// TLS certificate when the cert/key files are replaced on disk, without a pod
+// restart. This is the regression test for the cert-rotation bug where
+// GetConfigForClient, AddListener, and certKeyPair.Run were not wired up,
+// causing the server to serve the initial static cert forever.
+//
+// The test intentionally connects by IP (no SNI) to exercise the non-SNI code
+// path in GetConfigForClient — exactly the path the original bug exposed.
+func TestSecureServerCertRotation(t *testing.T) {
+	testPort, err := getFreePort(testHostname)
+	require.NoError(t, err)
+
+	tmpDir, err := os.MkdirTemp("", "server-test-cert-rotation")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	certFile := filepath.Join(tmpDir, "server.cert")
+	keyFile := filepath.Join(tmpDir, "server.key")
+	testServerHostPort := fmt.Sprintf("%v:%v", testHostname, testPort)
+
+	err = generateCertificate(t, certFile, keyFile, testServerHostPort)
+	require.NoError(t, err)
+
+	// Save the working directory so we can restore it after the test.
+	// prepareServerAssets calls os.Chdir; without restoring, subsequent tests
+	// that use relative paths (e.g. TestFilesHandler → http.Dir("testdata"))
+	// would run from the deleted tmpDir and fail.
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	tmpDirAssets := prepareServerAssets(t)
+	defer func() {
+		os.RemoveAll(tmpDirAssets)
+		os.Chdir(originalDir) //nolint:errcheck
+	}()
+
+	go func() {
+		Start(&Config{
+			CertFile:       certFile,
+			PrivateKeyFile: keyFile,
+			Port:           testPort,
+		})
+	}()
+
+	serverURL := fmt.Sprintf("https://%s", testServerHostPort)
+	httpClient, err := (&httpClientConfig{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+	}).buildHTTPClient()
+	require.NoError(t, err)
+
+	checkHTTPReady(httpClient, serverURL+"/health")
+
+	initialSerial, err := getServedCertSerial(testHostname, testPort)
+	require.NoError(t, err)
+	t.Logf("Initial cert serial: %X", initialSerial)
+
+	// Replace the cert/key files on disk to simulate certificate rotation.
+	err = generateCertificate(t, certFile, keyFile, testServerHostPort)
+	require.NoError(t, err)
+	t.Logf("Cert/key files replaced on disk")
+
+	// Poll until the server begins serving the new cert. The dynamic controller
+	// detects the file change via fsnotify and reloads within a few seconds.
+	var rotatedSerial *big.Int
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		serial, dialErr := getServedCertSerial(testHostname, testPort)
+		if dialErr == nil && serial.Cmp(initialSerial) != 0 {
+			rotatedSerial = serial
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	require.NotNil(t, rotatedSerial, "server must serve the new cert within 30s of file replacement")
+	t.Logf("Rotated cert serial: %X", rotatedSerial)
+
+	_, err = getRequestResults(t, httpClient, serverURL+"/health")
+	require.NoError(t, err, "server must remain healthy after cert rotation")
+}
+
+// getServedCertSerial dials the TLS server at host:port and returns the serial
+// number of the presented leaf certificate. Connecting by IP without a
+// server-name hint (no SNI) is intentional — this exercises the code path in
+// DynamicServingCertificateController.GetConfigForClient that selects the cert
+// for clients that omit SNI, which is exactly how in-cluster scanners connect
+// to a pod IP directly.
+func getServedCertSerial(host string, port int) (*big.Int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	dialer := tls.Dialer{Config: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+	conn, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	certs := conn.(*tls.Conn).ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no peer certificates presented")
+	}
+	return certs[0].SerialNumber, nil
+}
+
 func TestFilesHandler(t *testing.T) {
-	fs := http.Dir("testdata")
+	_, thisFile, _, _ := runtime.Caller(0)
+	fs := http.Dir(filepath.Join(filepath.Dir(thisFile), "testdata"))
 	handler := filesHandler(fs)
 
 	req := httptest.NewRequest("GET", "/index.html", nil)

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -79,10 +79,13 @@ The test suite includes comprehensive PatternFly-aware custom commands:
 - **PatternFly selectors**: `cy.pfMenuToggle()`, `cy.pfMenuItem()`, `cy.pfButton()`
 - **Trace testing**: `cy.muiTraceLink()`, `cy.muiSpanBar()`, `cy.muiTraceAttributes()`
 - **Bulk validation**: Commands for validating multiple trace attributes efficiently
+- **Chainsaw integration**: `cy.runChainsawTest(testDirs, description, options?)` runs chainsaw tests from Cypress; accepts a single directory name, an array of directories, or full paths starting with `./`; supports optional `timeout` and `extraArgs`
+- **Trace UI verification**: `cy.verifyTracesVisible(tempoInstance, tenant)` navigates to traces page and asserts traces are visible for the given Tempo instance and tenant
+- **OCP compatibility**: `cy.dismissWelcomeModal()` handles the OCP 4.22+ "Welcome to the new OpenShift experience!" modal overlay
 
 #### Test Types
-1. **Cypress E2E Tests**: Main UI automation testing the plugin functionality
-2. **Chainsaw Tests**: Kubernetes-native testing for RBAC and operator behavior
+1. **Cypress E2E Tests**: Main UI automation testing the plugin functionality (11 tests covering empty state, trace visualization, RBAC, trace limits, cutoff box, AI analysis, TraceQL queries, custom time range, scatter plot, attribute-based filtering, TLS profiles, and operator installation). Validated on OCP 4.22 nightly.
+2. **Chainsaw Tests**: Kubernetes-native testing for RBAC, TLS profiles, and operator behavior
 3. **Debug Tests**: Rapid iteration tests without full setup/teardown
 
 ### Operator Testing
@@ -113,6 +116,62 @@ mv e2e/dt-plugin-tests-debug.cy.ts.skip e2e/dt-plugin-tests-debug.cy.ts
 
 ### RBAC Testing
 Chainsaw tests in `fixtures/chainsaw-tests/` validate operator permissions and multi-tenancy scenarios.
+
+### TLS Profile Testing
+Chainsaw tests in `fixtures/chainsaw-tests/tls-profile-*` verify the plugin backend's TLS min version and cipher suite configuration. The tests use a `tls-scanner` pod (nmap/openssl) to scan the plugin's port 9443 and verify the advertised TLS versions and cipher suites match the configured profile. The operator is scaled down during testing to prevent reconciliation of manual deployment patches.
+
+Profiles tested: Intermediate (default), Modern (TLS 1.3 only), Custom cipher suites, Old (TLS 1.0+).
+
+Shared helpers live in `fixtures/chainsaw-tests/tls-profile/tls-helpers.sh`. Each profile is a separate chainsaw test directory invoked via `cy.runChainsawTest()` from the Cypress `[Capability:TLSProfile]` test, with `cy.verifyTracesVisible()` called after each to confirm the UI still works.
+
+## Cypress MCP Setup
+
+The Cypress MCP server provides Claude Code with tools to run Cypress tests, manage spec files, and automate browsers. To set it up:
+
+### 1. Clone the cypress-mcp repository
+```bash
+cd ~
+git clone git@github.com:yashpreetbathla/cypress-mcp.git
+```
+
+### 2. Install dependencies and build
+```bash
+cd ~/cypress-mcp
+npm install
+npm run build
+```
+
+### 3. Install Playwright Chromium (one-time, for browser automation tools)
+```bash
+npx playwright install chromium
+```
+
+### 4. Install Chromium for cypress-mcp's playwright-core version
+```bash
+cd ~/cypress-mcp
+node node_modules/playwright-core/cli.js install chromium
+```
+
+### 5. Configure MCP server
+Create `.mcp.json` in the project root (`distributed-tracing-console-plugin/.mcp.json`):
+```json
+{
+  "mcpServers": {
+    "cypress": {
+      "command": "node",
+      "args": ["<home>/cypress-mcp/dist/index.js", "--project", "<project-root>/tests"]
+    }
+  }
+}
+```
+Replace `<home>` with your home directory path and `<project-root>` with the absolute path to the distributed-tracing-console-plugin repository. The `--project` flag points to `tests/` where `cypress.config.ts` and the spec files live.
+
+### 6. Restart Claude Code
+Restart Claude Code to activate the MCP server. You will be prompted to approve the `cypress` server on first launch.
+
+### Notes
+- `.mcp.json` lives in the project root so it is picked up automatically without needing to change directories.
+- `.mcp.json` contains local absolute paths and is already listed in `.gitignore`.
 
 ## Documentation
 - **SELECTOR_BEST_PRACTICES.md**: Comprehensive selector guidelines

--- a/tests/PATTERNFLY_COMMANDS_EXAMPLES.md
+++ b/tests/PATTERNFLY_COMMANDS_EXAMPLES.md
@@ -153,6 +153,44 @@ cy.pfCloseButton('Close label group').click();     // PatternFly 6
 cy.pfCloseButton().click();                        // First close button found (any version)
 ```
 
+### Attribute Filter Interactions
+
+```typescript
+// Switch filter type (default is "Service Name")
+cy.pfMenuToggle('Service Name').click();
+cy.pfSelectMenuItem('Span Name').click();
+
+// Open multi-select checkbox dropdown and select first option
+cy.pfMenuToggleByLabel('Multi typeahead checkbox').click();
+cy.get('.pf-v6-c-menu__item input[type="checkbox"], .pf-v5-c-menu__item input[type="checkbox"]')
+  .first()
+  .check();
+
+// Switch to Status filter and verify predefined options
+cy.pfMenuToggle('Span Name').click();
+cy.pfSelectMenuItem('Status').click();
+cy.pfMenuToggleByLabel('Multi typeahead checkbox').click();
+cy.pfCheckMenuItem('unset');
+cy.pfCheckMenuItem('error');
+
+// Switch to Span Duration filter with min/max inputs
+cy.pfMenuToggle('Status').click();
+cy.pfSelectMenuItem('Span Duration').click();
+cy.get('#min-duration-input').clear().type('1ms');
+cy.wait(1500); // Duration inputs have 1000ms debounce
+cy.get('#max-duration-input').clear().type('10s');
+cy.wait(1500);
+
+// Verify toolbar chip shows duration range
+cy.get('.pf-v6-c-label__content, .pf-v5-c-label__content')
+  .should('contain', '1ms')
+  .and('contain', '10s');
+
+// Clear filter chip groups
+cy.pfCloseButtonIfExists('Close chip group');
+cy.pfCloseButtonIfExists('Close label group');
+```
+
 ### Trace & Span Interactions
 
 ```typescript
@@ -297,6 +335,101 @@ describe('AI Trace Summary', () => {
 });
 ```
 
+### Custom Time Range Selection
+
+```typescript
+// Select a preset time range via MUI Select
+cy.muiSelect('Select time range').click();
+cy.muiSelectOption('Last 1 hour').click();
+
+// Open the custom time range picker
+cy.muiSelect('Select time range').click();
+cy.muiSelectOption('Custom Time Range').click();
+
+// Verify the DateTimeRangePicker popover opens
+cy.contains('.MuiPopover-paper', 'Apply', { timeout: 10000 }).should('be.visible');
+
+// Check popover structure
+cy.contains('.MuiPopover-paper', 'Apply').within(() => {
+  cy.contains('Select Start Time').should('be.visible');
+  cy.get('label').contains('Start Time').should('exist');
+  cy.get('label').contains('End Time').should('exist');
+});
+
+// Apply the pre-populated custom time range
+cy.contains('.MuiPopover-paper', 'Apply').within(() => {
+  cy.get('button.MuiButton-contained').contains('Apply').click();
+});
+
+// Cancel the custom time range
+cy.contains('.MuiPopover-paper', 'Apply').within(() => {
+  cy.get('button.MuiButton-outlined').contains('Cancel').click();
+});
+
+// Verify URL params after custom range apply
+cy.url().should('match', /start=\d+/);   // Absolute timestamp
+cy.url().should('match', /end=\d+/);
+
+// Verify URL params after preset selection
+cy.url().should('include', 'start=1h');   // Relative duration
+```
+
+### Scatter Plot Interactions
+
+```typescript
+// Verify scatter plot is rendered with ECharts
+cy.get('[data-testid="ScatterChartPanel_ScatterPlot"]').should('be.visible');
+cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] canvas').should('exist');
+cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] > div')
+  .should('have.attr', '_echarts_instance_');
+
+// Toggle scatter plot visibility
+cy.contains('button', 'Hide graph').click();
+cy.get('[data-testid="ScatterChartPanel_ScatterPlot"]').should('not.exist');
+cy.contains('button', 'Show graph').click();
+cy.get('[data-testid="ScatterChartPanel_ScatterPlot"]').should('be.visible');
+
+// Trigger tooltip via mousemove on canvas
+cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] canvas').first()
+  .trigger('mousemove', 'center', { force: true });
+
+// Validate canvas has rendered content (non-empty pixels)
+cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] canvas').first().then(($canvas) => {
+  const canvas = $canvas[0] as HTMLCanvasElement;
+  const ctx = canvas.getContext('2d');
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const hasContent = imageData.data.some((val, idx) => idx % 4 !== 3 && val !== 0);
+  expect(hasContent).to.be.true;
+});
+```
+
+### Chainsaw & TLS Verification
+
+```typescript
+// Run a single chainsaw test directory (path relative to fixtures/chainsaw-tests/)
+cy.runChainsawTest('tls-profile-modern', 'Modern TLS profile');
+
+// Run multiple chainsaw test directories
+cy.runChainsawTest(
+  ['multitenancy-rbac', 'monolithic-multitenancy-rbac'],
+  'Create TempoStack and TempoMonolithic instances',
+  { timeout: 1200000 },
+);
+
+// Run a chainsaw test from a custom path (starts with ./)
+cy.runChainsawTest(
+  './fixtures/lightspeed',
+  'Lightspeed setup',
+  {
+    timeout: 1800000,
+    extraArgs: '--values - <<EOF\nKEY: value\nEOF',
+  },
+);
+
+// Verify traces are visible in the UI for a given Tempo instance and tenant
+cy.verifyTracesVisible('chainsaw-rbac / simplst', 'dev');
+```
+
 ## 🔄 PatternFly 5 & 6 Compatibility
 
 Our commands seamlessly support both PatternFly 5 and PatternFly 6 components:
@@ -384,6 +517,20 @@ cy.pfMenuItem('TempoStack', { timeout: 10000 }).click();
 4. **Break complex operations** into smaller, testable steps
 5. **Handle uncaught exceptions** gracefully in support files
 6. **Use timeouts** for components that load asynchronously
+
+### OCP Version Compatibility
+
+```typescript
+// Dismiss the OCP 4.22+ "Welcome to the new OpenShift experience!" modal
+// Call after cy.visit() to any page — no-op on older OCP versions
+cy.dismissWelcomeModal();
+
+// Typical usage pattern after navigating to a page
+cy.visit('/observe/traces');
+cy.url().should('include', '/observe/traces');
+cy.dismissWelcomeModal();
+cy.get('body').should('be.visible');
+```
 
 ## 🔧 Troubleshooting
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -117,6 +117,7 @@ This project includes a comprehensive set of custom Cypress commands optimized f
 - **Component-aware interactions** for PatternFly elements
 - **Bulk validation** for trace attributes (75% code reduction)
 - **Debug-friendly** commands with built-in logging
+- **OCP version compatibility** with `cy.dismissWelcomeModal()` for OCP 4.22+ modal handling
 
 ### Key Command Categories
 
@@ -175,6 +176,33 @@ Chainsaw tests in `fixtures/chainsaw-tests/` validate operator permissions and m
 
 These tests ensure that the distributed tracing plugin works correctly with different RBAC configurations and deployment models, supporting both upstream and downstream environments.
 
+### Chainsaw TLS Profile Testing
+Chainsaw tests in `fixtures/chainsaw-tests/tls-profile-*` verify that the plugin backend correctly enforces TLS minimum version and cipher suite configuration. Since the Cluster Observability Operator does not yet propagate TLS profile settings, the tests scale down the operator to prevent reconciliation, then patch the plugin deployment directly with `TLS_MIN_VERSION` and `TLS_CIPHER_SUITES` environment variables.
+
+Each TLS profile is a separate chainsaw test directory:
+
+| Directory | Description |
+|-----------|-------------|
+| `tls-profile-setup` | Installs the `tls-scanner` pod (nmap + openssl) and scales down the observability-operator |
+| `tls-profile-intermediate` | Verifies the default profile: TLS 1.2 + TLS 1.3 accepted |
+| `tls-profile-modern` | Patches `TLS_MIN_VERSION=VersionTLS13` and verifies only TLS 1.3 is accepted, TLS 1.2 is rejected |
+| `tls-profile-custom-ciphers` | Patches `TLS_CIPHER_SUITES` to restrict TLS 1.2 ciphers and verifies only specified ciphers are offered |
+| `tls-profile-old` | Patches `TLS_MIN_VERSION=VersionTLS10` and verifies TLS 1.0/1.1/1.2/1.3 are all accepted |
+| `tls-profile-revert` | Reverts env vars, verifies Intermediate profile is restored, scales operator back up, cleans up tls-scanner |
+
+Shared helper functions (`tls-helpers.sh`) and resource files live in `fixtures/chainsaw-tests/tls-profile/`.
+
+The Cypress test (`[Capability:TLSProfile]`) runs each chainsaw test in order and verifies traces remain visible in the UI after each profile change.
+
+To run the TLS profile chainsaw tests standalone (without Cypress):
+```bash
+export KUBECONFIG=~/Downloads/kubeconfig
+cd tests
+for test in tls-profile-setup tls-profile-intermediate tls-profile-modern tls-profile-custom-ciphers tls-profile-old tls-profile-revert; do
+  chainsaw test --config ./fixtures/.chainsaw.yaml --skip-delete ./fixtures/chainsaw-tests/$test
+done
+```
+
 ### Chainsaw Lightspeed Setup
 Chainsaw tests in `fixtures/lightspeed/` handle initial setup of OpenShift Lightspeed for AI-powered trace analysis integration:
 
@@ -192,8 +220,19 @@ EOF
 
 Ensure the environment variables are set before running Cypress tests to properly configure Lightspeed.
 
+### Cypress MCP Server (AI-Assisted Testing)
+
+The project supports the [cypress-mcp](https://github.com/yashpreetbathla/cypress-mcp) MCP server, which gives Claude Code tools to run Cypress tests, manage spec files, and automate browsers. See the "Cypress MCP Setup" section in `CLAUDE.md` for setup instructions.
+
+With the MCP server configured, Claude Code can:
+- List and read spec files (`cypress_list_specs`, `cypress_read_spec`)
+- Run tests and get structured results (`cypress_run`)
+- Open the Cypress GUI (`cypress_open`)
+- Automate a browser for visual inspection (`cypress_navigate`, `cypress_screenshot`, `cypress_snapshot`)
+
 ### Documentation
 - **CLAUDE.md** - Guidance for Claude AI assistance with this codebase
 - **SELECTOR_BEST_PRACTICES.md** - Comprehensive selector guidelines and command usage
 - **PATTERNFLY_COMMANDS_EXAMPLES.md** - Complete command examples and workflows
+- **TEST_COVERAGE_REPORT.md** - Detailed test coverage analysis and gap report
 - **README.md** - This file with setup and architecture overview

--- a/tests/SELECTOR_BEST_PRACTICES.md
+++ b/tests/SELECTOR_BEST_PRACTICES.md
@@ -90,6 +90,12 @@ cy.get(OLS_SELECTORS.promptInput)           // Textarea for prompt input
 cy.interceptQuery('alias', 'query text', 'conversation-id', [{ attachment_type: 'trace', content_type: 'application/json' }])
 cy.interceptQueryWithError('alias', 'query', 'error message')
 cy.interceptFeedback('alias', 'conversation-id', sentiment, 'feedback', 'question starts with')
+
+// Chainsaw Integration & Trace Verification
+cy.runChainsawTest('tls-profile-modern', 'Modern TLS profile')          // Single test dir
+cy.runChainsawTest(['multitenancy-rbac', 'monolithic-multitenancy-rbac'], 'RBAC tests', { timeout: 1200000 })  // Multiple dirs
+cy.runChainsawTest('./fixtures/lightspeed', 'Lightspeed setup', { timeout: 1800000, extraArgs: '--values ...' }) // Custom path
+cy.verifyTracesVisible('chainsaw-rbac / simplst', 'dev')                // Assert traces visible in UI
 ```
 
 ### Accessibility-Based Selectors

--- a/tests/TEST_COVERAGE_REPORT.md
+++ b/tests/TEST_COVERAGE_REPORT.md
@@ -1,15 +1,15 @@
 # Test Coverage Report - Distributed Tracing Console Plugin
-**Generated:** February 27, 2026
+**Generated:** April 30, 2026
 **Test Framework:** Cypress E2E
 **Test File:** `tests/e2e/dt-plugin-tests.cy.ts`
 
 ## Executive Summary
 
-This report provides a comprehensive analysis of the current Cypress E2E test coverage for the OpenShift Distributed Tracing Console Plugin. The test suite covers core functionality across plugin installation, trace visualization, RBAC, span links navigation, TraceQL queries, AI-powered trace analysis, and operator installation workflows.
+This report provides a comprehensive analysis of the current Cypress E2E test coverage for the OpenShift Distributed Tracing Console Plugin. The test suite covers core functionality across plugin installation, trace visualization, RBAC, span links navigation, TraceQL queries, AI-powered trace analysis, custom time range selection, scatter plot interaction, attribute-based filtering, and operator installation workflows.
 
-**Overall Coverage:** ~85% of core features
-**Total Tests:** 7 main test cases
-**Lines of Test Code:** 991 lines
+**Overall Coverage:** ~97% of core features
+**Total Tests:** 11 main test cases
+**Lines of Test Code:** ~1300 lines
 
 ---
 
@@ -77,6 +77,10 @@ This report provides a comprehensive analysis of the current Cypress E2E test co
 | **Time Range Selection** | | |
 | - Time range picker | Test 2, lines 524-525, 596-597, 645-646, 678-679, Test 5, lines 797-798 | Full |
 | - Multiple time ranges (15 min, 1 hour) | Test 2, Test 5 | Full |
+| - Custom time range (absolute dates) | Test 7 (CustomTimeRange) | Full |
+| - Custom time range Apply/Cancel | Test 7 (CustomTimeRange) | Full |
+| - Preset/Custom range switching | Test 7 (CustomTimeRange) | Full |
+| - URL parameter persistence (start/end) | Test 7 (CustomTimeRange) | Full |
 | **Service Filtering** | | |
 | - Service name multi-select | Test 2, lines 526-531, 598-603, 647-652, 680-685 | Full |
 | - Multiple service selection | Test 2 (http-rbac-1, http-rbac-2, grpc-rbac-1, grpc-rbac-2) | Full |
@@ -177,7 +181,75 @@ This report provides a comprehensive analysis of the current Cypress E2E test co
 | - Cluster-admin role testing | Test 2, title line 497 | Full |
 | - TempoStack RBAC | Test 2, chainsaw RBAC tests | Full |
 | - TempoMonolithic RBAC | Test 2, chainsaw RBAC tests | Full |
-| - Chainsaw RBAC test execution | Test 2, lines 498-511 | Full |
+| - Chainsaw RBAC test execution | Test 2, via cy.runChainsawTest() | Full |
+
+---
+
+### 9. Scatter Plot Visualization
+
+| Feature | Test Coverage | Coverage Level |
+|---------|--------------|---------------|
+| - Scatter plot container rendering | Test 8, `[data-testid="ScatterChartPanel_ScatterPlot"]` | Full |
+| - Canvas element presence | Test 8, canvas existence check | Full |
+| - Hide/Show graph toggle | Test 8, "Hide graph"/"Show graph" button | Full |
+| - ECharts instance initialization | Test 8, `_echarts_instance_` attribute check | Full |
+| - Tooltip on hover | Test 8, mousemove trigger + content check | Partial |
+| - Canvas content rendering | Test 8, pixel data validation | Full |
+
+---
+
+### 10. Custom Time Range
+
+| Feature | Test Coverage | Coverage Level |
+|---------|--------------|---------------|
+| - Preset time range selection | Test 7, "Last 1 hour" selection | Full |
+| - Custom Time Range menu item | Test 7, dropdown "Custom Time Range" option | Full |
+| - DateTimeRangePicker popover | Test 7, popover structure verification | Full |
+| - Start/End DateTimeField inputs | Test 7, label existence check | Full |
+| - Apply button functionality | Test 7, apply pre-populated range | Full |
+| - Cancel button functionality | Test 7, cancel preserves previous range | Full |
+| - URL absolute time params | Test 7, `start=<timestamp>&end=<timestamp>` | Full |
+| - Switch back to preset | Test 7, "Last 1 hour" after custom range | Full |
+
+---
+
+### 11. Attribute-Based Filtering
+
+| Feature | Test Coverage | Coverage Level |
+|---------|--------------|---------------|
+| - Filter type switcher | Test 9, switch between Service Name, Span Name, Status, Span Duration | Full |
+| - Span Name filter | Test 9, multi-select checkbox with typeahead | Full |
+| - Status filter (predefined options) | Test 9, unset/ok/error options verification | Full |
+| - Span Duration filter (min/max) | Test 9, `#min-duration-input` and `#max-duration-input` | Full |
+| - Duration chip labels | Test 9, "between X and Y" toolbar chip | Full |
+| - Filter clear and recovery | Test 9, clear chip groups and verify traces reappear | Full |
+
+---
+
+### 12. TLS Profile Configuration
+
+| Feature | Test Coverage | Coverage Level |
+|---------|--------------|---------------|
+| **TLS Profile Verification** | | |
+| - Default Intermediate profile (TLS 1.2 + 1.3) | Test 7, tls-profile-intermediate chainsaw test | Full |
+| - Modern profile (TLS 1.3 only) | Test 7, tls-profile-modern chainsaw test | Full |
+| - Custom cipher suites | Test 7, tls-profile-custom-ciphers chainsaw test | Full |
+| - Old profile (TLS 1.0+) | Test 7, tls-profile-old chainsaw test | Full |
+| - Profile revert to default | Test 7, tls-profile-revert chainsaw test | Full |
+| **nmap Endpoint Scanning** | | |
+| - TLS version enumeration (ssl-enum-ciphers) | All TLS chainsaw tests | Full |
+| - Cipher suite verification | tls-profile-custom-ciphers | Full |
+| - TLS 1.2 rejection under Modern profile (openssl) | tls-profile-modern | Full |
+| **Functional Endpoint Checks** | | |
+| - /health endpoint under each profile | All TLS chainsaw tests | Full |
+| - /features endpoint under each profile | All TLS chainsaw tests | Full |
+| - /plugin-manifest.json under each profile | All TLS chainsaw tests | Full |
+| **UI Verification** | | |
+| - Traces visible after each profile change | Test 7, cy.verifyTracesVisible() | Full |
+| **Operator Management** | | |
+| - Operator scale-down for testing | tls-profile-setup | Full |
+| - Operator scale-up after testing | tls-profile-revert | Full |
+| - tls-scanner pod lifecycle | tls-profile-setup/revert | Full |
 
 ---
 
@@ -187,9 +259,9 @@ This report provides a comprehensive analysis of the current Cypress E2E test co
 
 | Feature | Current Coverage | Recommendation |
 |---------|-----------------|----------------|
-| **Attribute-based filtering** | None | Test filtering by custom attributes (duration, status, etc.) |
+| **Attribute-based filtering** | Test 10 | Span Name, Status, Span Duration filters with chip verification |
 | **Error trace filtering** | None | Test filtering traces with errors/exceptions |
-| **Scatter plot visualization** | None | Test scatter plot rendering and interaction |
+| **Scatter plot visualization** | Test 9 | Toggle, rendering, ECharts instance, canvas content |
 | **Direct trace ID lookup** | None | Test navigating to trace by ID |
 | **Trace comparison** | None | Test side-by-side trace comparison (if feature exists) |
 | **Export functionality** | None | Test trace export to JSON/other formats (if feature exists) |
@@ -204,7 +276,7 @@ This report provides a comprehensive analysis of the current Cypress E2E test co
 | **Loading states** | None | Test loading spinners during trace fetch |
 | **Pagination** | Partial | Test page navigation beyond limit select |
 | **Refresh functionality** | None | Test manual trace list refresh |
-| **Time range picker edge cases** | Partial | Test custom time range input |
+| **Time range picker edge cases** | Test 8 | Custom time range with Apply/Cancel and preset switching |
 | **Multi-filter combinations** | Partial | Test complex filter scenarios |
 | **Filter persistence** | None | Test filter state after navigation |
 | **Keyboard navigation** | None | Test keyboard shortcuts and accessibility |
@@ -242,8 +314,12 @@ graph TD
     F --> J[Test 4: Cutoff Box]
     F --> K[Test 5: AI Analysis]
     F --> L[Test 6: TraceQL Query]
-    F --> P[Test 7: Install Operator]
-    P --> M[after hook]
+    F --> O[Test 7: Custom Time Range]
+    F --> P[Test 8: Scatter Plot]
+    F --> Q[Test 9: Attribute Filters]
+    F --> S[Test 10: TLS Profiles]
+    F --> R[Test 11: Install Operator]
+    R --> M[after hook]
     M --> N[Cleanup Resources]
 ```
 
@@ -255,6 +331,8 @@ graph TD
 | **Material-UI** | muiSelect, muiSelectOption, muiFirstTraceLink, muiTraceAttribute, muiTraceAttributes | Excellent |
 | **Tracing-specific** | setupTracePage, navigateToTraceDetails, dragCutoffResizer, verifyCutoffPosition, verifyTraceCount, menuToggleContains | Good |
 | **Lightspeed** | olsHelpers.waitForPopoverAndClose, olsHelpers.verifyPopoverVisible, olsHelpers.submitPrompt, olsHelpers.waitForAIResponse, olsHelpers.getAIResponse | Good |
+| **Chainsaw & Verification** | runChainsawTest, verifyTracesVisible | Good |
+| **OCP Compatibility** | dismissWelcomeModal (OCP 4.22+ modal dismissal) | Good |
 | **System** | cy.exec, cy.adminCLI, cy.login, cy.executeAndDelete | Excellent |
 
 ---
@@ -273,6 +351,7 @@ graph TD
 8. **Chainsaw integration:** Backend RBAC tests complement UI tests
 9. **TraceQL coverage:** Query editor interaction tested via CodeMirror EditorView API
 10. **Deterministic waits:** Span bar rendering waits prevent intermittent failures in headless mode
+11. **OCP version compatibility:** `dismissWelcomeModal` handles OCP 4.22+ onboarding modal; uncaught exception handler covers plugin initialization errors across versions
 
 ### Areas for Improvement
 
@@ -290,10 +369,16 @@ graph TD
 
 ### Recently Completed
 
-- **Operator not installed empty state:** Test 7 covers the full "Install Tempo operator" workflow including empty state verification ("Tempo operator isn't installed yet"), button visibility, OperatorHub redirect, and operator details page verification (lines 939-991).
-- **OperatorHub integration:** Test 7 validates the end-to-end flow from empty state through to the OperatorHub catalog page and operator install button.
-- **TraceQL query and empty results:** Test 6 covers TraceQL query editor interaction, custom query execution (`{ name = "/test" }`), "No results found" empty state verification, "Clear all filters" button functionality, query reset to default `{}`, and trace list recovery after clearing filters (lines 874-937).
+- **OCP 4.22 compatibility:** Added `dismissWelcomeModal` command to handle the "Welcome to the new OpenShift experience!" modal introduced in OCP 4.22. Uses `cy.document().querySelector()` for reliable detection and targets the modal's close button via `aria-label="Close"`. Also added `before initialization` pattern to the uncaught exception handler for Lightspeed plugin errors on OCP 4.22.
+- **Attribute-based filtering:** Test 9 covers switching between filter types (Span Name, Status, Span Duration), selecting values via multi-select checkboxes, entering min/max duration with debounced inputs, verifying toolbar chip labels, and clearing filters to recover unfiltered results.
+- **Custom time range selection:** Test 7 covers the Perses `TimeRangeControls` custom time range workflow — opening the DateTimeRangePicker popover, verifying its structure (calendar, Start/End fields, Apply/Cancel), applying the pre-populated absolute range, verifying URL switches from relative (`start=1h`) to absolute (`start=<ms>&end=<ms>`), testing Cancel preserves the range, and switching back to a preset.
+- **Scatter plot visualization:** Test 8 covers the ECharts-based scatter plot — verifying the container (`[data-testid="ScatterChartPanel_ScatterPlot"]`) and canvas render, testing the Hide/Show graph toggle, confirming ECharts initialization via `_echarts_instance_` attribute, triggering tooltip via mousemove, and validating canvas pixel content is non-empty.
+- **Operator not installed empty state:** Test 11 covers the full "Install Tempo operator" workflow including empty state verification ("Tempo operator isn't installed yet"), button visibility, OperatorHub redirect, and operator details page verification.
+- **OperatorHub integration:** Test 11 validates the end-to-end flow from empty state through to the OperatorHub catalog page and operator install button.
+- **TraceQL query and empty results:** Test 6 covers TraceQL query editor interaction, custom query execution (`{ name = "/test" }`), "No results found" empty state verification, "Clear all filters" button functionality, query reset to default `{}`, and trace list recovery after clearing filters.
 - **Headless mode stability:** Added deterministic waits for span bar rendering across all trace detail interactions, and page reload guards for navigation after long-running commands, reducing intermittent failures in headless Chrome.
+- **TLS profile testing:** Test 7 validates plugin backend TLS configuration (min version, cipher suites) across Intermediate, Modern, Custom cipher, and Old profiles using nmap/openssl scanning via chainsaw tests, with UI trace verification after each profile change.
+- **Chainsaw integration command:** `cy.runChainsawTest()` provides a reusable command for invoking chainsaw tests from Cypress, supporting single/multiple test directories, custom timeouts, and extra arguments. `cy.verifyTracesVisible()` provides quick UI-level trace verification.
 
 ### Immediate Actions (Sprint 1)
 
@@ -313,9 +398,7 @@ graph TD
 
 ### Short-term Goals (2-3 Sprints)
 
-3. **Attribute-based filtering:** Test filtering by duration, status code, etc.
-4. **Scatter plot interaction:** Test scatter plot rendering and drill-down
-5. **URL persistence:** Test that filters persist in URL parameters
+3. **URL persistence:** Test that filters persist in URL parameters
 6. **Documentation links:** Verify "View documentation" button navigates to correct URL (currently only visibility is tested in Test 1)
 
 ### Long-term Goals (Future)
@@ -330,29 +413,33 @@ graph TD
 
 ## Feature-to-Test Mapping Matrix
 
-| Feature | Test 1 | Test 2 | Test 3 | Test 4 | Test 5 | Test 6 | Test 7 | Coverage % |
-|---------|--------|--------|--------|--------|--------|--------|--------|-----------|
-| Empty State UI | Y | - | - | - | - | - | - | 100% |
-| Install Operator Flow | - | - | - | - | - | - | Y | 100% |
-| Tempo Instance Selection | - | Y | Y | Y | Y | Y | - | 100% |
-| Tenant Selection | - | Y | Y | Y | Y | Y | - | 100% |
-| Time Range Selection | - | Y | - | - | Y | - | - | 100% |
-| Service Filtering | - | Y | - | - | Y | - | - | 100% |
-| Namespace Filtering | - | - | Y | - | - | - | - | 100% |
-| Trace Limit Control | - | - | Y | - | - | - | - | 100% |
-| Trace Navigation | - | Y | - | - | Y | - | - | 100% |
-| Span Details | - | Y | - | Y | - | - | - | 100% |
-| Span Links | - | Y | - | - | - | - | - | 100% |
-| Breadcrumb Navigation | - | Y | - | - | - | - | - | 100% |
-| Timeline Cutoff | - | - | - | Y | - | - | - | 100% |
-| AI Analysis | - | - | - | - | Y | - | - | 100% |
-| TraceQL Queries | - | - | - | - | - | Y | - | 100% |
-| Empty Query Results | - | - | - | - | - | Y | - | 100% |
-| Clear Filters | - | - | - | - | - | Y | - | 100% |
-| Attribute Filters | - | - | - | - | - | - | - | 0% |
-| Error Handling | - | - | - | - | - | - | - | 0% |
-| Scatter Plot | - | - | - | - | - | - | - | 0% |
-| Documentation Links | Partial | - | - | - | - | - | - | 25% |
+| Feature | Test 1 | Test 2 | Test 3 | Test 4 | Test 5 | Test 6 | Test 7 | Test 8 | Test 9 | Test 10 | Test 11 | Coverage % |
+|---------|--------|--------|--------|--------|--------|--------|--------|--------|--------|---------|---------|-----------|
+| Empty State UI | Y | - | - | - | - | - | - | - | - | - | - | 100% |
+| Install Operator Flow | - | - | - | - | - | - | - | - | - | - | Y | 100% |
+| Tempo Instance Selection | - | Y | Y | Y | Y | Y | Y | Y | Y | - | - | 100% |
+| Tenant Selection | - | Y | Y | Y | Y | Y | Y | Y | Y | - | - | 100% |
+| Time Range Selection | - | Y | - | - | Y | - | Y | Y | Y | - | - | 100% |
+| Custom Time Range | - | - | - | - | - | - | Y | - | - | - | - | 100% |
+| Service Filtering | - | Y | - | - | Y | - | - | - | - | - | - | 100% |
+| Namespace Filtering | - | - | Y | - | - | - | - | - | - | - | - | 100% |
+| Span Name Filtering | - | - | - | - | - | - | - | - | Y | - | - | 100% |
+| Status Filtering | - | - | - | - | - | - | - | - | Y | - | - | 100% |
+| Duration Filtering | - | - | - | - | - | - | - | - | Y | - | - | 100% |
+| Trace Limit Control | - | - | Y | - | - | - | - | - | - | - | - | 100% |
+| Trace Navigation | - | Y | - | - | Y | - | - | - | - | - | - | 100% |
+| Span Details | - | Y | - | Y | - | - | - | - | - | - | - | 100% |
+| Span Links | - | Y | - | - | - | - | - | - | - | - | - | 100% |
+| Breadcrumb Navigation | - | Y | - | - | - | - | - | Y | - | - | - | 100% |
+| Timeline Cutoff | - | - | - | Y | - | - | - | - | - | - | - | 100% |
+| AI Analysis | - | - | - | - | Y | - | - | - | - | - | - | 100% |
+| TraceQL Queries | - | - | - | - | - | Y | - | - | - | - | - | 100% |
+| Empty Query Results | - | - | - | - | - | Y | - | - | - | - | - | 100% |
+| Clear Filters | - | - | - | - | - | Y | - | - | Y | - | - | 100% |
+| TLS Profile Config | - | - | - | - | - | - | - | - | - | Y | - | 100% |
+| Scatter Plot | - | - | - | - | - | - | - | Y | - | - | - | 100% |
+| Error Handling | - | - | - | - | - | - | - | - | - | - | - | 0% |
+| Documentation Links | Partial | - | - | - | - | - | - | - | - | - | - | 25% |
 
 ---
 
@@ -423,8 +510,57 @@ graph TD
 - Query reset to default `{}`
 - Trace list recovery after clearing filters
 
-### Test 7: Install Operator
-**File:** `dt-plugin-tests.cy.ts`, lines 939-991
+### Test 7: Custom Time Range
+**File:** `dt-plugin-tests.cy.ts`, `[Capability:CustomTimeRange]` test
+**Purpose:** Test custom time range selection, Apply/Cancel, and preset switching
+**Features Covered:**
+- Preset time range selection ("Last 1 hour") with URL param verification (`start=1h`)
+- "Custom Time Range" menu item opens DateTimeRangePicker popover
+- Popover structure: "Select Start Time", Start/End DateTimeField inputs, Apply/Cancel buttons
+- Apply pre-populated custom range and verify URL switches to absolute timestamps
+- Dropdown displays formatted date range after applying custom range
+- Cancel closes popover and preserves previous time range
+- Switch back to preset after custom range
+
+### Test 8: Scatter Plot
+**File:** `dt-plugin-tests.cy.ts`, `[Capability:ScatterPlot]` test
+**Purpose:** Test scatter plot visibility, ECharts rendering, and toggle interaction
+**Features Covered:**
+- Scatter plot container (`[data-testid="ScatterChartPanel_ScatterPlot"]`) rendering
+- Canvas element presence
+- "Hide graph" / "Show graph" toggle functionality
+- ECharts instance initialization (`_echarts_instance_` attribute)
+- Tooltip hover interaction (mousemove on canvas)
+- Canvas pixel content validation (non-empty rendering)
+
+### Test 9: Attribute Filters
+**File:** `dt-plugin-tests.cy.ts`, `[Capability:AttributeFilters]` test
+**Purpose:** Test attribute-based filtering with Span Name, Status, and Span Duration
+**Features Covered:**
+- Filter type switcher (Service Name → Span Name → Status → Span Duration)
+- Span Name multi-select with typeahead checkbox options
+- Status filter with predefined options (unset, ok, error)
+- Span Duration filter with min/max duration inputs (`#min-duration-input`, `#max-duration-input`)
+- Duration format validation and debounce (1000ms)
+- Toolbar filter chip labels ("between 1ms and 10s")
+- Filter clear and recovery to unfiltered state
+
+### Test 10: TLS Profile Configuration
+**File:** `dt-plugin-tests.cy.ts`, `[Capability:TLSProfile]` test
+**Purpose:** Verify plugin backend TLS min version and cipher suite enforcement
+**Features Covered:**
+- tls-scanner pod deployment and cleanup
+- Operator scale-down/up to prevent reconciliation
+- Intermediate profile verification (TLS 1.2 + 1.3, nmap + endpoints)
+- Modern profile verification (TLS 1.3 only, TLS 1.2 rejection via openssl)
+- Custom cipher suite verification (restricted TLS 1.2 ciphers, nmap enumeration)
+- Old profile verification (TLS 1.0/1.1/1.2/1.3, nmap)
+- Revert to default and verify Intermediate restored
+- UI trace visibility after each profile change (cy.verifyTracesVisible)
+- Uses 6 individual chainsaw tests invoked via cy.runChainsawTest()
+
+### Test 11: Install Operator
+**File:** `dt-plugin-tests.cy.ts`, `[Capability:OperatorLifecycle]` test
 **Purpose:** Test "Install Tempo operator" button workflow
 **Features Covered:**
 - Chainsaw namespace cleanup
@@ -439,21 +575,17 @@ graph TD
 
 ## Conclusion
 
-The current test suite provides **excellent coverage** of core tracing functionality, RBAC, TraceQL queries, AI integration, and operator installation workflows. Test 6 covers the TraceQL query editor interaction, empty query results handling, and clear filters functionality. Test 7 covers the complete "Install Tempo operator" empty state workflow. The main remaining gaps are in:
-1. **Advanced filtering (attributes, errors)**
-2. **Error handling scenarios**
-3. **Scatter plot interaction**
-4. **UI edge cases**
+The current test suite provides **excellent coverage** of core tracing functionality, RBAC, TraceQL queries, AI integration, custom time range selection, scatter plot visualization, attribute-based filtering, TLS profile configuration, and operator installation workflows. The suite is validated on OCP 4.22 nightly with backwards-compatible handling of the new welcome modal. Test 7 covers custom time range selection, Test 8 covers scatter plot visualization, Test 9 covers attribute-based filtering, and Test 10 covers TLS profile configuration. The main remaining gaps are in:
+1. **Error handling scenarios**
+2. **UI edge cases**
 
 **Recommended Next Steps:**
 1. Split Test 2 into focused tests (maintainability)
-2. Add attribute-based filtering tests (completeness)
-3. Add scatter plot interaction test (visualization coverage)
-4. Expand error handling tests (robustness)
+2. Expand error handling tests (robustness)
 
 The test suite demonstrates excellent use of custom commands, page object patterns, PatternFly version-agnostic selectors, and CodeMirror EditorView API integration, making it maintainable and extensible for future feature additions.
 
 ---
 
 **Report prepared by:** Claude Code
-**Last updated:** February 27, 2026
+**Last updated:** April 30, 2026

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -67,6 +67,9 @@ declare global {
       navigateToTraceDetails(): Chainable<void>;
       dragCutoffResizer(position: number, resizerType?: 'left' | 'right'): Chainable<void>;
       verifyCutoffPosition(expectedWidthPercent: number, tolerance?: number): Chainable<void>;
+      // Chainsaw and TLS verification commands
+      runChainsawTest(testDirs: string | string[], description: string, options?: { timeout?: number; extraArgs?: string }): Chainable<void>;
+      verifyTracesVisible(tempoInstance: string, tenant: string): Chainable<void>;
     }
   }
 }
@@ -81,6 +84,7 @@ declare global {
       cliLogout(): Chainable<Element>;
       adminCLI(command: string, options?: any): Chainable<Element>;
       login(provider?: string, username?: string, password?: string): Chainable<Element>;
+      dismissWelcomeModal(): Chainable<void>;
       executeAndDelete(command: string): Chainable<Element>;
       // Lightspeed/OLS specific commands
       interceptFeedback(
@@ -350,6 +354,60 @@ Cypress.Commands.add('executeAndDelete', (command: string) => {
         cy.task('log', `Command "${command}" executed successfully`);
       }
     });
+});
+
+// Dismiss any modal overlay (e.g. OCP 4.22+ "Welcome" modal) if present.
+// Polls for up to 10 seconds on first call; subsequent calls do a single quick check.
+let welcomeModalSeen = false;
+let welcomeModalChecked = false;
+Cypress.Commands.add('dismissWelcomeModal', () => {
+  const dismissIfPresent = (doc: Document): boolean => {
+    const modalCloseBtn = doc.querySelector('.pf-v6-c-modal-box button[aria-label="Close"], .pf-v5-c-modal-box button[aria-label="Close"]');
+    if (modalCloseBtn) {
+      cy.log('Modal overlay detected, clicking close button');
+      cy.wrap(modalCloseBtn).click({ force: true });
+      cy.wait(1000);
+      welcomeModalSeen = true;
+      return true;
+    }
+    const modalBox = doc.querySelector('.pf-v6-c-modal-box, .pf-v5-c-modal-box');
+    if (modalBox) {
+      cy.log('Modal overlay detected, clicking first non-Learn button');
+      cy.get('.pf-v6-c-modal-box button, .pf-v5-c-modal-box button')
+        .not(':contains("Learn")')
+        .first()
+        .click({ force: true });
+      cy.wait(1000);
+      welcomeModalSeen = true;
+      return true;
+    }
+    return false;
+  };
+
+  if (!welcomeModalChecked) {
+    // First time: poll up to 5 times to catch modals that render with delay
+    const checkAndDismiss = (attemptsLeft = 5) => {
+      cy.wait(2000);
+      cy.document().then((doc) => {
+        if (dismissIfPresent(doc)) {
+          welcomeModalChecked = true;
+          return;
+        }
+        if (attemptsLeft > 0) {
+          checkAndDismiss(attemptsLeft - 1);
+        } else {
+          welcomeModalChecked = true;
+        }
+      });
+    };
+    checkAndDismiss();
+  } else if (welcomeModalSeen) {
+    // Modal was seen before — do a quick single check in case it reappears
+    cy.wait(1000);
+    cy.document().then((doc) => {
+      dismissIfPresent(doc);
+    });
+  }
 });
 
 // Best practice selector commands following accessibility and stability guidelines
@@ -717,6 +775,7 @@ Cypress.Commands.add(
     cy.reload();
     cy.visit('/observe/traces');
     cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
     // Wait for the Tempo instance typeahead to confirm the page is fully loaded
     cy.get('input[placeholder="Select a Tempo instance"]', { timeout: 30000 }).should('exist');
 
@@ -823,6 +882,50 @@ Cypress.Commands.add(
 
         cy.log(`✓ Cutoff box width is ${widthValue}% (within acceptable range of ${minWidth}-${maxWidth}%)`);
       });
+  },
+);
+
+// Chainsaw and TLS verification commands
+
+Cypress.Commands.add(
+  'runChainsawTest',
+  (testDirs: string | string[], description: string, options?: { timeout?: number; extraArgs?: string }) => {
+    const dirs = Array.isArray(testDirs) ? testDirs : [testDirs];
+    const paths = dirs.map((d) => d.startsWith('./') ? d : `./fixtures/chainsaw-tests/${d}`).join(' ');
+    const extraArgs = options?.extraArgs ? ` ${options.extraArgs}` : '';
+    const timeout = options?.timeout ?? 600000;
+
+    cy.log(`Run chainsaw test: ${description}`);
+    cy.exec(
+      `chainsaw test --config ./fixtures/.chainsaw.yaml --skip-delete ${paths}${extraArgs}`,
+      {
+        env: { KUBECONFIG: Cypress.env('KUBECONFIG_PATH') },
+        timeout,
+        failOnNonZeroExit: true,
+      },
+    ).then((result) => {
+      expect(result.code).to.eq(0);
+      cy.log(`${description}: ${result.stdout}`);
+    });
+  },
+);
+
+Cypress.Commands.add(
+  'verifyTracesVisible',
+  (tempoInstance: string, tenant: string) => {
+    cy.log('Verify traces are visible in the UI');
+    cy.visit('/observe/traces');
+    cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
+    cy.get('input[placeholder="Select a Tempo instance"]', { timeout: 30000 }).should('exist');
+    cy.pfTypeahead('Select a Tempo instance').click();
+    cy.pfSelectMenuItem(tempoInstance).click();
+    cy.pfTypeahead('Select a tenant').click();
+    cy.pfSelectMenuItem(tenant).click();
+    cy.muiSelect('Select time range').click();
+    cy.muiSelectOption('Last 1 hour').click();
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+    cy.log('PASS: Traces are visible in the UI');
   },
 );
 

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -7,10 +7,11 @@ registerCypressGrep();
 Cypress.on('uncaught:exception', (err, runnable) => {
   // Return false to prevent the test from failing on uncaught exceptions
   // that might be caused by the application's React state management
-  if (err.message.includes('e is not a function') || 
+  if (err.message.includes('e is not a function') ||
       err.message.includes('Cannot read prop') ||
       err.message.includes('undefined is not a function') ||
-      err.message.includes('Cannot read properties of undefined')) {
+      err.message.includes('Cannot read properties of undefined') ||
+      err.message.includes('before initialization')) {
     console.log('Caught application error:', err.message);
     return false;
   }

--- a/tests/e2e/dt-plugin-tests.cy.ts
+++ b/tests/e2e/dt-plugin-tests.cy.ts
@@ -940,6 +940,296 @@ EOF`,
     cy.log('✓ TraceQL query with no results and clear filters functionality verified');
   });
 
+  it('[Capability:UIPlugin][Capability:CustomTimeRange] Test custom time range selection and preset switching', () => {
+    cy.log('Navigate to the /observe/traces page');
+    cy.visit('/observe/traces');
+    cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
+    cy.get('input[placeholder="Select a Tempo instance"]', { timeout: 30000 }).should('exist');
+
+    cy.log('Select TempoStack instance: chainsaw-rbac / simplst');
+    cy.pfTypeahead('Select a Tempo instance').click();
+    cy.pfSelectMenuItem('chainsaw-rbac / simplst').click();
+
+    cy.log('Select tenant: dev');
+    cy.pfTypeahead('Select a tenant').click();
+    cy.pfSelectMenuItem('dev').click();
+
+    cy.log('Select preset time range: Last 1 hour');
+    cy.muiSelect('Select time range').click();
+    cy.muiSelectOption('Last 1 hour').click();
+
+    cy.log('Verify traces appear with the preset time range');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+
+    cy.log('Verify URL contains the relative time range parameter');
+    cy.url().should('include', 'start=1h');
+
+    cy.log('Open the time range dropdown and select Custom Time Range');
+    cy.muiSelect('Select time range').click();
+    cy.muiSelectOption('Custom Time Range').click();
+
+    cy.log('Verify the DateTimeRangePicker popover opens with expected elements');
+    cy.contains('.MuiPopover-paper', 'Apply', { timeout: 10000 })
+      .should('be.visible')
+      .as('datePickerPopover');
+
+    cy.get('@datePickerPopover').within(() => {
+      cy.contains('Select Start Time').should('be.visible');
+      cy.get('label').contains('Start Time').should('exist');
+      cy.get('label').contains('End Time').should('exist');
+      cy.get('button.MuiButton-contained').contains('Apply').should('be.visible');
+      cy.get('button.MuiButton-outlined').contains('Cancel').should('be.visible');
+    });
+
+    cy.log('Apply the pre-populated custom time range');
+    cy.get('@datePickerPopover').within(() => {
+      cy.get('button.MuiButton-contained').contains('Apply').click();
+    });
+
+    cy.log('Verify the popover closes after Apply');
+    cy.contains('.MuiPopover-paper', 'Apply').should('not.exist');
+
+    cy.log('Verify URL switches to absolute time range parameters');
+    cy.url().should('match', /start=\d+/);
+    cy.url().should('match', /end=\d+/);
+    cy.url().should('not.include', 'start=1h');
+
+    cy.log('Verify the time range dropdown displays the custom date range');
+    cy.muiSelect('Select time range').invoke('text').should('match', /\d{4}-\d{2}-\d{2}/);
+
+    cy.log('Verify traces are still visible within the custom time range');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+
+    cy.log('Reopen custom time range to test Cancel flow');
+    cy.muiSelect('Select time range').click();
+    cy.get('[role="listbox"] [role="option"]').last().click();
+
+    cy.log('Verify the DateTimeRangePicker popover opens');
+    cy.contains('.MuiPopover-paper', 'Apply', { timeout: 10000 }).should('be.visible');
+
+    cy.log('Click Cancel without making changes');
+    cy.contains('.MuiPopover-paper', 'Apply').within(() => {
+      cy.get('button.MuiButton-outlined').contains('Cancel').click();
+    });
+
+    cy.log('Verify the popover closes after Cancel');
+    cy.contains('.MuiPopover-paper', 'Apply').should('not.exist');
+
+    cy.log('Verify the previous custom time range is preserved in URL');
+    cy.url().should('match', /start=\d+/);
+    cy.url().should('match', /end=\d+/);
+
+    cy.log('Switch back to preset: Last 1 hour');
+    cy.muiSelect('Select time range').click();
+    cy.muiSelectOption('Last 1 hour').click();
+
+    cy.log('Verify URL reverts to relative time range');
+    cy.url().should('include', 'start=1h');
+
+    cy.log('Verify traces are visible with the preset time range');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+  });
+
+  it('[Capability:UIPlugin][Capability:ScatterPlot] Test scatter plot visibility toggle and trace navigation', () => {
+    cy.log('Navigate to the /observe/traces page');
+    cy.visit('/observe/traces');
+    cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
+    cy.get('input[placeholder="Select a Tempo instance"]', { timeout: 30000 }).should('exist');
+
+    cy.log('Select TempoStack instance: chainsaw-rbac / simplst');
+    cy.pfTypeahead('Select a Tempo instance').click();
+    cy.pfSelectMenuItem('chainsaw-rbac / simplst').click();
+
+    cy.log('Select tenant: dev');
+    cy.pfTypeahead('Select a tenant').click();
+    cy.pfSelectMenuItem('dev').click();
+
+    cy.log('Select time range: Last 1 hour');
+    cy.muiSelect('Select time range').click();
+    cy.muiSelectOption('Last 1 hour').click();
+
+    cy.log('Wait for traces to load');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+
+    cy.log('Verify scatter plot container and canvas are rendered');
+    cy.get('[data-testid="ScatterChartPanel_ScatterPlot"]', { timeout: 10000 }).should('be.visible');
+    cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] canvas').should('exist');
+
+    cy.log('Test Hide graph toggle');
+    cy.contains('button', 'Hide graph').should('be.visible').click();
+    cy.get('[data-testid="ScatterChartPanel_ScatterPlot"]').should('not.exist');
+
+    cy.log('Test Show graph toggle');
+    cy.contains('button', 'Show graph').should('be.visible').click();
+    cy.get('[data-testid="ScatterChartPanel_ScatterPlot"]', { timeout: 10000 }).should('be.visible');
+    cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] canvas').should('exist');
+
+    cy.log('Verify scatter plot ECharts container has instance attribute');
+    cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] > div').should('have.attr', '_echarts_instance_');
+
+    cy.log('Trigger tooltip by hovering over scatter plot canvas');
+    cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] canvas').first()
+      .trigger('mousemove', 'center', { force: true });
+    cy.wait(1000);
+
+    cy.log('Verify tooltip content if visible');
+    cy.get('body').then(($body) => {
+      if ($body.find('div:contains("Service name")').length > 0) {
+        cy.contains('Service name').should('be.visible');
+        cy.contains('Span name').should('be.visible');
+        cy.contains('Duration').should('be.visible');
+        cy.contains('Span count').should('be.visible');
+        cy.log('Tooltip verified with trace details');
+      } else {
+        cy.log('Tooltip not rendered at center position, skipping tooltip content check');
+      }
+    });
+
+    cy.log('Verify scatter plot renders data points by checking canvas is non-empty');
+    cy.get('[data-testid="ScatterChartPanel_ScatterPlot"] canvas').first().then(($canvas) => {
+      const canvas = $canvas[0] as HTMLCanvasElement;
+      const ctx = canvas.getContext('2d');
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const hasContent = imageData.data.some((val, idx) => idx % 4 !== 3 && val !== 0);
+      expect(hasContent, 'Canvas should have rendered content (axes, data points)').to.be.true;
+    });
+  });
+
+  it('[Capability:UIPlugin][Capability:AttributeFilters] Test attribute-based filtering with Span Name, Status, and Span Duration filters', () => {
+    cy.log('Navigate to the /observe/traces page');
+    cy.visit('/observe/traces');
+    cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
+    cy.get('input[placeholder="Select a Tempo instance"]', { timeout: 30000 }).should('exist');
+
+    cy.log('Select TempoStack instance: chainsaw-rbac / simplst');
+    cy.pfTypeahead('Select a Tempo instance').click();
+    cy.pfSelectMenuItem('chainsaw-rbac / simplst').click();
+
+    cy.log('Select tenant: dev');
+    cy.pfTypeahead('Select a tenant').click();
+    cy.pfSelectMenuItem('dev').click();
+
+    cy.log('Select time range: Last 1 hour');
+    cy.muiSelect('Select time range').click();
+    cy.muiSelectOption('Last 1 hour').click();
+
+    cy.log('Wait for traces to load');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+
+    cy.log('Switch filter type to Span Name');
+    cy.contains('label', 'Filter').parents('.pf-v6-c-form__group, .pf-v5-c-form__group').first()
+      .find('.pf-v6-c-menu-toggle, .pf-v5-c-menu-toggle').first().click();
+    cy.pfSelectMenuItem('Span Name').click();
+
+    cy.log('Open Span Name multi-select and verify options appear');
+    cy.pfMenuToggleByLabel('Multi typeahead checkbox').click();
+    cy.get('.pf-v6-c-menu__item input[type="checkbox"], .pf-v5-c-menu__item input[type="checkbox"]', { timeout: 10000 })
+      .should('have.length.greaterThan', 0);
+
+    cy.log('Select the first span name option');
+    cy.get('.pf-v6-c-menu__item input[type="checkbox"], .pf-v5-c-menu__item input[type="checkbox"]')
+      .first()
+      .check();
+
+    cy.log('Verify traces are still visible after Span Name filter');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+
+    cy.log('Clear the Span Name filter chip group');
+    cy.pfCloseButtonIfExists('Close chip group');
+    cy.pfCloseButtonIfExists('Close label group');
+
+    cy.log('Switch filter type to Status');
+    cy.contains('label', 'Filter').parents('.pf-v6-c-form__group, .pf-v5-c-form__group').first()
+      .find('.pf-v6-c-menu-toggle, .pf-v5-c-menu-toggle').first().click();
+    cy.pfSelectMenuItem('Status').click();
+
+    cy.log('Open Status multi-select and verify predefined options');
+    cy.pfMenuToggleByLabel('Multi typeahead checkbox').click();
+    cy.get('.pf-v6-c-menu__item-text, .pf-v5-c-menu__item-text', { timeout: 10000 })
+      .should('contain', 'unset')
+      .and('contain', 'ok')
+      .and('contain', 'error');
+
+    cy.log('Select status: unset');
+    cy.pfCheckMenuItem('unset');
+
+    cy.log('Verify traces appear with unset status filter');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+
+    cy.log('Clear the Status filter chip group');
+    cy.pfCloseButtonIfExists('Close chip group');
+    cy.pfCloseButtonIfExists('Close label group');
+
+    cy.log('Switch filter type to Span Duration');
+    cy.contains('label', 'Filter').parents('.pf-v6-c-form__group, .pf-v5-c-form__group').first()
+      .find('.pf-v6-c-menu-toggle, .pf-v5-c-menu-toggle').first().click();
+    cy.pfSelectMenuItem('Span Duration').click();
+
+    cy.log('Enter min duration: 1ms');
+    cy.get('#min-duration-input').should('be.visible').clear().type('1ms');
+    cy.wait(1500);
+
+    cy.log('Verify toolbar chip shows duration filter');
+    cy.get('.pf-v6-c-label__content, .pf-v5-c-label__content, .pf-v6-c-chip__text, .pf-v5-c-chip__text', { timeout: 5000 })
+      .should('contain', '1ms');
+
+    cy.log('Enter max duration: 10s');
+    cy.get('#max-duration-input').should('be.visible').clear().type('10s');
+    cy.wait(1500);
+
+    cy.log('Verify toolbar chip shows duration range');
+    cy.get('.pf-v6-c-label__content, .pf-v5-c-label__content, .pf-v6-c-chip__text, .pf-v5-c-chip__text', { timeout: 5000 })
+      .should('contain', '1ms')
+      .and('contain', '10s');
+
+    cy.log('Verify traces are visible within the duration range');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+
+    cy.log('Clear the Span Duration filter');
+    cy.pfCloseButtonIfExists('Close chip group');
+    cy.pfCloseButtonIfExists('Close label group');
+
+    cy.log('Switch filter type back to Service Name');
+    cy.contains('label', 'Filter').parents('.pf-v6-c-form__group, .pf-v5-c-form__group').first()
+      .find('.pf-v6-c-menu-toggle, .pf-v5-c-menu-toggle').first().click();
+    cy.pfSelectMenuItem('Service Name').click();
+
+    cy.log('Verify traces are visible without any filters');
+    cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
+  });
+
+  it('[Capability:UIPlugin][Capability:TLSCertRotation] Test dynamic TLS certificate rotation without pod restart', function () {
+    cy.runChainsawTest('cert-rotation', 'TLS certificate rotation', { timeout: 600000 });
+  });
+
+  it('[Capability:UIPlugin][Capability:TLSProfile] Test TLS profile configuration on plugin endpoints', function () {
+    // Setup: install tls-scanner and scale down operator
+    cy.runChainsawTest('tls-profile-setup', 'TLS profile setup');
+
+    // Test default Intermediate profile (TLS 1.2 + TLS 1.3)
+    cy.runChainsawTest('tls-profile-intermediate', 'Intermediate TLS profile');
+    cy.verifyTracesVisible('chainsaw-rbac / simplst', 'dev');
+
+    // Test Modern profile (TLS 1.3 only)
+    cy.runChainsawTest('tls-profile-modern', 'Modern TLS profile');
+    cy.verifyTracesVisible('chainsaw-rbac / simplst', 'dev');
+
+    // Test Custom cipher suites
+    cy.runChainsawTest('tls-profile-custom-ciphers', 'Custom cipher suites');
+    cy.verifyTracesVisible('chainsaw-rbac / simplst', 'dev');
+
+    // Test Old profile (TLS 1.0+)
+    cy.runChainsawTest('tls-profile-old', 'Old TLS profile');
+    cy.verifyTracesVisible('chainsaw-rbac / simplst', 'dev');
+
+    // Revert to default, scale operator back up, cleanup tls-scanner
+    cy.runChainsawTest('tls-profile-revert', 'Revert to default');
+    cy.verifyTracesVisible('chainsaw-rbac / simplst', 'dev');
+  });
+
   it('[Capability:OperatorLifecycle][Capability:Installation] Test "Install Tempo operator" if operator is not installed', () => {
     cy.log('Delete Chainsaw test namespaces and resources');
     cy.exec(

--- a/tests/e2e/dt-plugin-tests.cy.ts
+++ b/tests/e2e/dt-plugin-tests.cy.ts
@@ -295,25 +295,21 @@ describe('tracing-uiplugin', () => {
     }
 
     cy.log('Run Lightspeed Chainsaw test to setup OLSConfig and credentials');
-    cy.exec(
-      `chainsaw test --config ./fixtures/.chainsaw.yaml --skip-delete --quiet ./fixtures/lightspeed --values - <<EOF
+    cy.runChainsawTest(
+      './fixtures/lightspeed',
+      'Lightspeed OLSConfig and credentials setup',
+      {
+        timeout: 1800000,
+        extraArgs: `--values - <<EOF
 LIGHTSPEED_PROVIDER_URL: ${Cypress.env('LIGHTSPEED_PROVIDER_URL')}
 LIGHTSPEED_PROVIDER_TOKEN: ${Cypress.env('LIGHTSPEED_PROVIDER_TOKEN')}
 EOF`,
-      {
-        env: {
-          KUBECONFIG: Cypress.env('KUBECONFIG_PATH'),
-        },
-        timeout: 1800000,
-        failOnNonZeroExit: true
-      }
-    ) .then((result) => {
-      expect(result.code).to.eq(0);
-      cy.log(`Lightspeed Chainsaw test ran successfully: ${result.stdout}`);
-    });
+      },
+    );
 
     cy.log('Wait for Lightspeed popover to open by default and close it');
     cy.visit('/');
+    cy.dismissWelcomeModal();
     olsHelpers.waitForPopoverAndClose();
 
     cy.log('Create Distributed Tracing UI Plugin instance.');
@@ -347,6 +343,7 @@ EOF`,
           cy.log('No web console update alert found after 2 minutes, navigating to traces page');
           cy.visit('/observe/traces');
           cy.url().should('include', '/observe/traces');
+          cy.dismissWelcomeModal();
           cy.get('body').should('be.visible');
           // Wait for the page to fully render
           cy.wait(3000);
@@ -464,6 +461,7 @@ EOF`,
     cy.log('Navigate to the observe/traces page');
     cy.visit('/observe/traces');
     cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
     cy.get('body').should('be.visible');
     // Wait a bit for the page to fully render
     cy.wait(3000);
@@ -496,19 +494,11 @@ EOF`,
 
   it('[Capability:UIPlugin][Capability:TraceVisualization][Capability:SpanLinks][Capability:RBAC] Test Distributed Tracing UI plugin with Tempo instances and verify traces, span links using user having cluster-admin role', function () {
     cy.log('Create TempoStack and TempoMonolithic instances');
-    cy.exec(
-      'chainsaw test --config ./fixtures/.chainsaw.yaml --skip-delete --quiet ./fixtures/chainsaw-tests',
-      {
-        env: {
-          KUBECONFIG: Cypress.env('KUBECONFIG_PATH'),
-        },
-        timeout: 1200000,
-        failOnNonZeroExit: true
-      }
-    ) .then((result) => {
-      expect(result.code).to.eq(0);
-      cy.log(`Chainsaw test ran successfully: ${result.stdout}`);
-    });
+    cy.runChainsawTest(
+      ['multitenancy-rbac', 'monolithic-multitenancy-rbac'],
+      'Create TempoStack and TempoMonolithic instances',
+      { timeout: 1200000 },
+    );
 
     cy.log('Navigate to the /observe/traces page');
     // Force a clean navigation after the long chainsaw exec to handle any console auto-reloads
@@ -537,7 +527,7 @@ EOF`,
     // Wait for attributes panel to load
     cy.get('.MuiListItemText-root', { timeout: 10000 }).should('be.visible');
     cy.muiTraceAttributes({
-      'network.peer.address': { value: '1.2.3.4' },
+      'network.peer.address': { value: ['1.2.3.4', '127.0.0.1'] },
       'peer.service': { value: (text) => ['telemetrygen-server', 'telemetrygen-client'].includes(text) },
       'k8s.container.name': { value: 'telemetrygen', optional: true },
       'k8s.namespace.name': {
@@ -576,12 +566,16 @@ EOF`,
     // Wait for trace detail page to fully render span bars after navigation
     cy.findByTestId('span-duration-bar', { timeout: 30000 }).should('have.length.greaterThan', 1);
     cy.findByTestId('span-duration-bar').eq(1).click();
-    // Switch to the Attributes tab (the Links tab may still be selected from the previous trace)
-    cy.get('button.MuiTab-root').contains('Attributes').click();
-    // Wait for attributes panel to load
-    cy.get('.MuiListItemText-root', { timeout: 10000 }).should('be.visible');
+    // Switch to the Attributes tab if tab bar is present, otherwise attributes are shown inline
+    cy.get('body').then(($body) => {
+      if ($body.find('button.MuiTab-root:contains("Attributes")').length > 0) {
+        cy.get('button.MuiTab-root').contains('Attributes').click();
+      }
+    });
+    // Wait for attributes to load
+    cy.get('.MuiListItemText-root, .MuiTypography-h5', { timeout: 10000 }).should('be.visible');
     cy.muiTraceAttributes({
-      'network.peer.address': { value: '1.2.3.4' },
+      'network.peer.address': { value: ['1.2.3.4', '127.0.0.1'] },
       'peer.service': { value: (text) => ['telemetrygen-server', 'telemetrygen-client'].includes(text) },
       'k8s.container.name': { value: 'telemetrygen', optional: true },
       'k8s.namespace.name': {
@@ -631,12 +625,16 @@ EOF`,
     // Wait for trace detail page to fully render span bars after navigation
     cy.findByTestId('span-duration-bar', { timeout: 30000 }).should('have.length.greaterThan', 1);
     cy.findByTestId('span-duration-bar').eq(1).click();
-    // Switch to the Attributes tab (the Links tab may still be selected from the previous trace)
-    cy.get('button.MuiTab-root').contains('Attributes').click();
-    // Wait for attributes panel to load
-    cy.get('.MuiListItemText-root', { timeout: 10000 }).should('be.visible');
+    // Switch to the Attributes tab if tab bar is present, otherwise attributes are shown inline
+    cy.get('body').then(($body) => {
+      if ($body.find('button.MuiTab-root:contains("Attributes")').length > 0) {
+        cy.get('button.MuiTab-root').contains('Attributes').click();
+      }
+    });
+    // Wait for attributes to load
+    cy.get('.MuiListItemText-root, .MuiTypography-h5', { timeout: 10000 }).should('be.visible');
     cy.muiTraceAttributes({
-      'network.peer.address': { value: '1.2.3.4' },
+      'network.peer.address': { value: ['1.2.3.4', '127.0.0.1'] },
       'peer.service': { value: (text) => ['telemetrygen-server', 'telemetrygen-client'].includes(text) },
       'k8s.container.name': { value: 'telemetrygen', optional: true },
       'k8s.namespace.name': {
@@ -669,7 +667,7 @@ EOF`,
     // Wait for attributes panel to load
     cy.get('.MuiListItemText-root', { timeout: 10000 }).should('be.visible');
     cy.muiTraceAttributes({
-      'network.peer.address': { value: '1.2.3.4' },
+      'network.peer.address': { value: ['1.2.3.4', '127.0.0.1'] },
       'peer.service': { value: (text) => ['telemetrygen-server', 'telemetrygen-client'].includes(text) },
       'k8s.container.name': { value: 'telemetrygen', optional: true },
       'k8s.namespace.name': {
@@ -703,7 +701,7 @@ EOF`,
     // Wait for attributes panel to load
     cy.get('.MuiListItemText-root', { timeout: 10000 }).should('be.visible');
     cy.muiTraceAttributes({
-      'network.peer.address': { value: '1.2.3.4' },
+      'network.peer.address': { value: ['1.2.3.4', '127.0.0.1'] },
       'peer.service': { value: (text) => ['telemetrygen-server', 'telemetrygen-client'].includes(text) },
       'k8s.container.name': { value: 'telemetrygen', optional: true },
       'k8s.namespace.name': {
@@ -724,6 +722,7 @@ EOF`,
     cy.log('Navigate to the observe/traces page');
     cy.visit('/observe/traces');
     cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
     cy.get('body').should('be.visible');
     // Wait for the page to fully render
     cy.wait(3000);
@@ -796,6 +795,7 @@ EOF`,
     cy.log('Navigate to the /observe/traces page');
     cy.visit('/observe/traces');
     cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
     cy.get('body').should('be.visible');
     // Wait for the page to fully render
     cy.wait(3000);
@@ -879,6 +879,7 @@ EOF`,
     cy.log('Navigate to the /observe/traces page');
     cy.visit('/observe/traces');
     cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
     cy.get('body').should('be.visible');
     cy.wait(3000);
 
@@ -1252,6 +1253,7 @@ EOF`,
     cy.log('Navigate to the observe/traces page');
     cy.visit('/observe/traces');
     cy.url().should('include', '/observe/traces');
+    cy.dismissWelcomeModal();
     cy.get('body').should('be.visible');
     cy.wait(3000);
 
@@ -1276,9 +1278,19 @@ EOF`,
     cy.log('Wait for catalog page to load completely');
     cy.wait(3000);
 
-    cy.log('Verify Tempo Operator details modal Install button exists');
-    // Support both old and new OpenShift versions
-    cy.get('[data-test="catalog-details-modal-cta"], [data-test-id="operator-install-btn"]', { timeout: 60000 }).should('exist');
+    cy.dismissWelcomeModal();
+
+    cy.log('Verify Tempo Operator is shown on the catalog/OperatorHub page');
+    // OCP 4.22+ uses a "Software Catalog" page with tiles; older versions show an OperatorHub modal
+    cy.get('body', { timeout: 60000 }).should('contain.text', 'Tempo');
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-test="catalog-details-modal-cta"], [data-test-id="operator-install-btn"]').length > 0) {
+        cy.log('Found OperatorHub install button (pre-4.22 flow)');
+      } else {
+        cy.log('Catalog page detected (4.22+ flow), verifying Tempo Operator tile is visible');
+        cy.contains('Tempo Operator').should('be.visible');
+      }
+    });
 
     cy.log('✓ "Install Tempo operator" button successfully redirects to OperatorHub');
   });

--- a/tests/fixtures/chainsaw-tests/cert-rotation/00-assert.yaml
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+status:
+  phase: Running

--- a/tests/fixtures/chainsaw-tests/cert-rotation/00-install-tls-scanner.yaml
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/00-install-tls-scanner.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-scanner-pods-reader-dt-plugin
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-scanner-pods-reader-dt-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-scanner-pods-reader-dt-plugin
+subjects:
+- kind: ServiceAccount
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: tls-scanner-scc-dt-plugin
+allowPrivilegedContainer: false
+allowPrivilegeEscalation: false
+allowHostNetwork: false
+allowHostPorts: false
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+  seLinuxOptions:
+    type: spc_t
+seccompProfiles:
+- 'runtime/default'
+users:
+- (join(':', ['system:serviceaccount', $COO_NAMESPACE, 'tls-scanner']))
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+  labels:
+    app: tls-scanner
+spec:
+  serviceAccountName: tls-scanner
+  containers:
+  - name: tls-scanner
+    image: quay.io/rhn_support_ikanse/tls-scanner@sha256:3f354b5f3f76a62f3e34edea3361ce79b4f010df1633d03f92e89f6a7a6f1f0b
+    command: ["sleep", "infinity"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  restartPolicy: Never

--- a/tests/fixtures/chainsaw-tests/cert-rotation/01-cert-rotation.sh
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/01-cert-rotation.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Verify that the distributed-tracing-console-plugin backend dynamically reloads
+# its TLS certificate after the serving secret is rotated, without a pod restart.
+#
+# Regression test for: GetConfigForClient / AddListener / certKeyPair.Run were
+# not wired up, so the server served its initial cert forever even after the
+# cert file on disk changed.
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+  -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "openshift-cluster-observability-operator")}"
+
+DEPLOYMENT="distributed-tracing"
+PLUGIN_PORT="9443"
+LABEL_SELECTOR="app.kubernetes.io/instance=distributed-tracing"
+SECRET_NAME="distributed-tracing"
+CERT_MOUNT_PATH="/var/serving-cert/tls.crt"
+
+fail() { echo "FAIL: $*"; exit 1; }
+
+openssl_serial() {
+  local ip="$1"
+  kubectl exec tls-scanner -n "$NAMESPACE" -- bash -c \
+    "echo '' | timeout 10 openssl s_client -connect ${ip}:${PLUGIN_PORT} 2>/dev/null \
+     | openssl x509 -noout -serial 2>/dev/null" 2>/dev/null || echo ""
+}
+
+echo "Using namespace: $NAMESPACE"
+echo "Deployment: $DEPLOYMENT"
+
+# ---------------------------------------------------------------------------
+# Step 1: Record pre-rotation state
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 1: Pre-rotation state ==="
+
+OLD_SECRET_SERIAL=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -serial 2>/dev/null)
+echo "Secret cert serial (pre-rotation):  $OLD_SECRET_SERIAL"
+
+# Capture the concrete pod name and IP once; reuse throughout the test so all
+# checks reference the same pod even if the label selector matches multiple pods.
+POD_NAME=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" \
+  --field-selector=status.phase=Running \
+  -o jsonpath='{.items[0].metadata.name}')
+[ -n "$POD_NAME" ] || fail "could not find a Running plugin pod"
+
+PLUGIN_IP=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.status.podIP}')
+[ -n "$PLUGIN_IP" ] || fail "could not get IP of pod $POD_NAME"
+
+POD_TS=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.creationTimestamp}')
+
+OLD_SERVED_SERIAL=$(openssl_serial "$PLUGIN_IP")
+echo "Served cert serial (pre-rotation):  ${OLD_SERVED_SERIAL:-<unavailable>}"
+echo "Plugin pod: $POD_NAME (created: $POD_TS)"
+
+# ---------------------------------------------------------------------------
+# Step 2: Delete secret — service-ca regenerates it with a new cert
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 2: Rotate the TLS secret ==="
+kubectl delete secret "$SECRET_NAME" -n "$NAMESPACE"
+echo "Secret deleted — waiting for service-ca to regenerate..."
+
+ELAPSED=0; TIMEOUT=120
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" &>/dev/null && break
+  sleep 2; ELAPSED=$((ELAPSED + 2))
+done
+[ $ELAPSED -lt $TIMEOUT ] || fail "secret not regenerated within ${TIMEOUT}s"
+echo "Secret regenerated after ~${ELAPSED}s"
+
+NEW_SECRET_SERIAL=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -serial 2>/dev/null)
+echo "Secret cert serial (post-rotation): $NEW_SECRET_SERIAL"
+
+[ "$OLD_SECRET_SERIAL" != "$NEW_SECRET_SERIAL" ] \
+  || fail "serial unchanged after secret regeneration — service-ca may not have rotated the cert"
+echo "PASS: New cert issued ($OLD_SECRET_SERIAL → $NEW_SECRET_SERIAL)"
+
+# ---------------------------------------------------------------------------
+# Step 3: Wait for the new cert to propagate to the pod's volume mount
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 3: Wait for volume propagation ==="
+
+EXPECTED_HASH=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d | sha256sum | awk '{print $1}')
+
+ELAPSED=0; TIMEOUT=180
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  ACTUAL_HASH=$(kubectl exec "deployment/$DEPLOYMENT" -n "$NAMESPACE" -- \
+    cat "$CERT_MOUNT_PATH" 2>/dev/null | sha256sum | awk '{print $1}') || true
+  [ "$EXPECTED_HASH" = "$ACTUAL_HASH" ] && break
+  [ $((ELAPSED % 30)) -eq 0 ] && echo "Waiting for volume sync... (${ELAPSED}s/${TIMEOUT}s)"
+  sleep 5; ELAPSED=$((ELAPSED + 5))
+done
+[ $ELAPSED -lt $TIMEOUT ] || fail "cert volume did not sync within ${TIMEOUT}s"
+echo "PASS: Volume propagation confirmed after ${ELAPSED}s"
+
+# ---------------------------------------------------------------------------
+# Step 4: Verify the server dynamically serves the new cert without restart
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 4: Verify dynamic cert reload (no pod restart) ==="
+
+SERVED_SERIAL=""
+ELAPSED=0; TIMEOUT=180
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  SERVED_SERIAL=$(openssl_serial "$PLUGIN_IP")
+  [ "$SERVED_SERIAL" = "$NEW_SECRET_SERIAL" ] && break
+  [ $((ELAPSED % 30)) -eq 0 ] \
+    && echo "Waiting for reload... (${ELAPSED}s/${TIMEOUT}s) served=${SERVED_SERIAL:-unknown}"
+  sleep 5; ELAPSED=$((ELAPSED + 5))
+done
+
+if [ "$SERVED_SERIAL" != "$NEW_SECRET_SERIAL" ]; then
+  fail "server did not pick up new cert within ${TIMEOUT}s (served=${SERVED_SERIAL:-unknown}, expected=${NEW_SECRET_SERIAL})"
+fi
+echo "PASS: Dynamic cert reload confirmed after ${ELAPSED}s"
+
+# ---------------------------------------------------------------------------
+# Step 5: Verify the pod was NOT restarted
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 5: Verify pod was not restarted ==="
+CURRENT_POD=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
+CURRENT_TS=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || echo "")
+
+if [ "$CURRENT_POD" = "$POD_NAME" ] && [ "$CURRENT_TS" = "$POD_TS" ]; then
+  echo "PASS: Same pod running (name=$POD_NAME, creationTimestamp=$POD_TS)"
+else
+  fail "pod was restarted: before=$POD_NAME/$POD_TS after=$CURRENT_POD/$CURRENT_TS"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: Verify the service endpoint is healthy with the new cert
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 6: Verify /health endpoint after cert rotation ==="
+SVC_URL="https://${DEPLOYMENT}.${NAMESPACE}.svc:${PLUGIN_PORT}/health"
+HTTP_CODE=$(kubectl exec tls-scanner -n "$NAMESPACE" -- \
+  curl -sk -o /dev/null -w '%{http_code}' "$SVC_URL" 2>/dev/null)
+[ "$HTTP_CODE" = "200" ] || fail "/health returned HTTP $HTTP_CODE (expected 200)"
+echo "PASS: /health → HTTP 200"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================="
+echo "PASS: Certificate rotation with dynamic reload verified"
+echo "  Pre-rotation serial:  $OLD_SECRET_SERIAL"
+echo "  Post-rotation serial: $NEW_SECRET_SERIAL"
+echo "  Served serial:        $SERVED_SERIAL"
+echo "  Pod not restarted:    $POD_NAME"
+echo "============================================="

--- a/tests/fixtures/chainsaw-tests/cert-rotation/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/chainsaw-test.yaml
@@ -1,0 +1,99 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cert-rotation
+spec:
+  steps:
+  - name: Detect COO namespace and install tls-scanner
+    try:
+    - command:
+        entrypoint: kubectl
+        args:
+        - get
+        - deployment
+        - -A
+        - -l app.kubernetes.io/name=observability-operator
+        - -o
+        - jsonpath={.items[0].metadata.namespace}
+        outputs:
+        - name: COO_NAMESPACE
+          value: ($stdout)
+    - script:
+        content: |
+          if [ -z "$COO_NAMESPACE" ]; then
+            echo "ERROR: COO_NAMESPACE is empty — observability-operator deployment not found" >&2
+            exit 1
+          fi
+          echo "Detected COO namespace: $COO_NAMESPACE"
+          # Clean up any leftover tls-scanner resources from a previous run
+          kubectl delete pod tls-scanner -n "$COO_NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+          kubectl delete sa tls-scanner -n "$COO_NAMESPACE" 2>/dev/null || true
+          sleep 3
+        env:
+        - name: COO_NAMESPACE
+          value: ($COO_NAMESPACE)
+    - apply:
+        file: 00-install-tls-scanner.yaml
+    - assert:
+        file: 00-assert.yaml
+
+  - name: Scale down observability-operator
+    try:
+    - script:
+        timeout: 2m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}')
+          kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=0
+          kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=60s
+          echo "PASS: observability-operator scaled to 0"
+
+  - name: Verify cert rotation and dynamic reload
+    try:
+    - script:
+        timeout: 10m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}')
+          export NAMESPACE
+          ./01-cert-rotation.sh
+
+  - name: Scale operator back up and cleanup tls-scanner
+    try:
+    - script:
+        timeout: 3m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}')
+          kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=1
+          kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=120s
+          echo "PASS: observability-operator scaled back to 1"
+    - script:
+        timeout: 2m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}')
+          kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+          kubectl delete sa tls-scanner -n "$NAMESPACE" 2>/dev/null || true
+          echo "PASS: tls-scanner resources cleaned up"
+
+  catch:
+  - script:
+      timeout: 3m
+      content: |
+        NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+          -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null)
+        NAMESPACE="${NAMESPACE:-openshift-cluster-observability-operator}"
+        kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=1 2>/dev/null || true
+        kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=120s || true
+        kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+        kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+        kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+        kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+        kubectl delete sa tls-scanner -n "$NAMESPACE" 2>/dev/null || true

--- a/tests/fixtures/chainsaw-tests/tls-profile-custom-ciphers/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-custom-ciphers/chainsaw-test.yaml
@@ -1,0 +1,49 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tls-profile-custom-ciphers
+spec:
+  steps:
+  - name: Patch deployment with custom cipher suites
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          patch_tls_env "VersionTLS12" "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+          echo "PASS: Deployment patched with custom cipher suites"
+  - name: Verify custom cipher suites
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          detect_fips
+
+          PLUGIN_IP=$(get_plugin_pod_ip)
+          NMAP_RESULT=$(kubectl exec tls-scanner -n "$NAMESPACE" -- \
+            nmap -Pn --script ssl-enum-ciphers -p "$PLUGIN_PORT" "$PLUGIN_IP")
+          echo "$NMAP_RESULT"
+
+          PORT_SECTION=$(echo "$NMAP_RESULT" | grep -A 100 "${PLUGIN_PORT}/tcp" || true)
+          [ -z "$PORT_SECTION" ] && fail "Port $PLUGIN_PORT not found in nmap output"
+
+          TLS12_SECTION=$(echo "$PORT_SECTION" | sed -n '/TLSv1.2/,/TLSv1.3\|least strength/p' || true)
+          if [ -n "$TLS12_SECTION" ]; then
+            echo "$TLS12_SECTION" | grep -i "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" \
+              || fail "Expected cipher TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 not found"
+            echo "$TLS12_SECTION" | grep -i "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" \
+              || fail "Expected cipher TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 not found"
+
+            FOUND_CIPHERS=$(echo "$TLS12_SECTION" | grep -oE 'TLS_[A-Z0-9_]+' | grep -v '^TLSv' | sort -u || true)
+            echo "Found TLS 1.2 ciphers: $FOUND_CIPHERS"
+            echo "$FOUND_CIPHERS" | while IFS= read -r cipher; do
+              [ -z "$cipher" ] && continue
+              echo "$cipher" | grep -qE "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" \
+                || fail "Unexpected TLS 1.2 cipher suite: $cipher"
+            done
+          fi
+
+          echo "$PORT_SECTION" | grep "TLSv1.3" || fail "TLS 1.3 should still be available"
+          verify_all_endpoints "Custom cipher suites"
+          echo "PASS: Custom cipher suite configuration verified"

--- a/tests/fixtures/chainsaw-tests/tls-profile-intermediate/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-intermediate/chainsaw-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tls-profile-intermediate
+spec:
+  steps:
+  - name: Verify default Intermediate TLS profile
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          detect_fips
+          remove_tls_env
+          verify_nmap_tls_profile "intermediate" "Default Intermediate profile"
+          verify_all_endpoints "Default Intermediate profile"
+          echo "PASS: Intermediate TLS profile verified (TLS 1.2 + TLS 1.3)"

--- a/tests/fixtures/chainsaw-tests/tls-profile-modern/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-modern/chainsaw-test.yaml
@@ -1,0 +1,25 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tls-profile-modern
+spec:
+  steps:
+  - name: Patch deployment for Modern TLS profile
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          patch_tls_env "VersionTLS13" ""
+          echo "PASS: Deployment patched with TLS_MIN_VERSION=VersionTLS13"
+  - name: Verify Modern TLS profile
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          detect_fips
+          verify_nmap_tls_profile "modern" "Modern profile"
+          verify_tls_version_rejected "-tls1_2" "TLS 1.2 rejected under Modern profile"
+          verify_all_endpoints "Modern profile"
+          echo "PASS: Modern TLS profile verified (TLS 1.3 only, TLS 1.2 rejected)"

--- a/tests/fixtures/chainsaw-tests/tls-profile-old/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-old/chainsaw-test.yaml
@@ -1,0 +1,24 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tls-profile-old
+spec:
+  steps:
+  - name: Patch deployment for Old TLS profile
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          patch_tls_env "VersionTLS10" ""
+          echo "PASS: Deployment patched with TLS_MIN_VERSION=VersionTLS10"
+  - name: Verify Old TLS profile
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          detect_fips
+          verify_nmap_tls_profile "old" "Old profile"
+          verify_all_endpoints "Old profile"
+          echo "PASS: Old TLS profile verified (TLS 1.0/1.1/1.2/1.3)"

--- a/tests/fixtures/chainsaw-tests/tls-profile-revert/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-revert/chainsaw-test.yaml
@@ -1,0 +1,53 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tls-profile-revert
+spec:
+  steps:
+  - name: Revert to default and verify Intermediate profile
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          detect_fips
+          remove_tls_env
+          verify_nmap_tls_profile "intermediate" "Reverted Intermediate profile"
+          verify_all_endpoints "Reverted Intermediate profile"
+          echo "PASS: Reverted to default Intermediate profile"
+  - name: Scale operator back up and cleanup tls-scanner
+    try:
+    - script:
+        timeout: 3m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          scale_up_operator
+          sleep 10
+          kubectl wait --for=condition=Ready pods -l "$LABEL_SELECTOR" -n "$NAMESPACE" --timeout=120s
+          echo "PASS: Operator scaled back up and plugin is healthy"
+    - script:
+        timeout: 2m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "openshift-cluster-observability-operator")
+          kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+          kubectl delete sa tls-scanner -n "$NAMESPACE" 2>/dev/null || true
+          echo "PASS: tls-scanner resources cleaned up"
+  catch:
+  - script:
+      timeout: 3m
+      content: |
+        NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+          -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "openshift-cluster-observability-operator")
+        kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=1 2>/dev/null || true
+        kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=120s || true
+        kubectl patch deployment distributed-tracing -n "$NAMESPACE" --type=json \
+          -p '[{"op": "remove", "path": "/spec/template/spec/containers/0/env"}]' 2>/dev/null || true
+        kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+        kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+        kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+        kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+        kubectl delete sa tls-scanner -n "$NAMESPACE" 2>/dev/null || true

--- a/tests/fixtures/chainsaw-tests/tls-profile-setup/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-setup/chainsaw-test.yaml
@@ -1,0 +1,43 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tls-profile-setup
+spec:
+  steps:
+  - name: Detect COO namespace and install tls-scanner
+    try:
+    - command:
+        entrypoint: oc
+        args:
+        - get
+        - deployment
+        - -A
+        - -l app.kubernetes.io/name=observability-operator
+        - -o
+        - jsonpath={.items[0].metadata.namespace}
+        outputs:
+        - name: COO_NAMESPACE
+          value: ($stdout)
+    - script:
+        timeout: 1m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null)
+          echo "Detected COO namespace: $NAMESPACE"
+          kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+          kubectl delete sa tls-scanner -n "$NAMESPACE" 2>/dev/null || true
+          sleep 5
+    - apply:
+        file: ../tls-profile/00-install-tls-scanner.yaml
+    - assert:
+        file: ../tls-profile/00-assert.yaml
+  - name: Scale down observability-operator
+    try:
+    - script:
+        timeout: 2m
+        content: |
+          . ../tls-profile/tls-helpers.sh
+          scale_down_operator

--- a/tests/fixtures/chainsaw-tests/tls-profile/00-assert.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+status:
+  phase: Running

--- a/tests/fixtures/chainsaw-tests/tls-profile/00-install-tls-scanner.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile/00-install-tls-scanner.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-scanner-pods-reader-dt-plugin
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-scanner-pods-reader-dt-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-scanner-pods-reader-dt-plugin
+subjects:
+- kind: ServiceAccount
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: tls-scanner-scc-dt-plugin
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowHostNetwork: false
+allowHostPorts: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+users:
+- (join(':', ['system:serviceaccount', $COO_NAMESPACE, 'tls-scanner']))
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+  labels:
+    app: tls-scanner
+spec:
+  serviceAccountName: tls-scanner
+  containers:
+  - name: tls-scanner
+    image: quay.io/rhn_support_ikanse/tls-scanner:latest
+    command: ["sleep", "infinity"]
+    securityContext:
+      privileged: true
+      runAsUser: 0
+  restartPolicy: Never

--- a/tests/fixtures/chainsaw-tests/tls-profile/01-verify-default-intermediate.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/01-verify-default-intermediate.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify default TLS profile (Intermediate): TLS 1.2 + TLS 1.3 supported.
+# No TLS env vars are set on the deployment; the plugin uses its built-in defaults.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+detect_fips
+
+echo "============================================="
+echo "Step 1: Verify default Intermediate TLS profile"
+echo "============================================="
+
+# --- 1. Verify no TLS env vars are set ---
+echo "=== Checking deployment has no TLS env vars ==="
+CONTAINER_ENV=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env}' 2>/dev/null || echo "null")
+if [ "$CONTAINER_ENV" != "" ] && [ "$CONTAINER_ENV" != "null" ]; then
+  if echo "$CONTAINER_ENV" | grep -q "TLS_MIN_VERSION\|TLS_CIPHER_SUITES"; then
+    fail "TLS env vars are set but should not be for default profile test"
+  fi
+fi
+echo "PASS: No TLS env vars set on deployment"
+
+# --- 2. Verify deployment args (should NOT have --tls-min-version or --tls-cipher-suites) ---
+echo "=== Checking deployment args ==="
+CONTAINER_ARGS=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].args}')
+echo "Container args: $CONTAINER_ARGS"
+if echo "$CONTAINER_ARGS" | grep -q "tls-min-version\|tls-cipher-suites"; then
+  echo "NOTE: TLS args found in container args - these were set explicitly"
+fi
+
+# --- 3. nmap scan to verify Intermediate profile (TLS 1.2 + TLS 1.3) ---
+verify_nmap_tls_profile "intermediate" "Default Intermediate profile"
+
+# --- 4. Functional endpoint checks ---
+verify_all_endpoints "Default Intermediate profile"
+
+echo ""
+echo "============================================="
+echo "PASS: Default Intermediate TLS profile verified"
+echo "  - TLS 1.2 and TLS 1.3 both supported"
+echo "  - All endpoints responding correctly"
+echo "============================================="

--- a/tests/fixtures/chainsaw-tests/tls-profile/01a-scale-down-operator.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/01a-scale-down-operator.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Scale down the Cluster Observability Operator before patching the plugin
+# deployment. The operator owns the deployment and will reconcile away any
+# manual env-var changes if left running.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+echo "============================================="
+echo "Step 1a: Scale down observability-operator"
+echo "============================================="
+
+scale_down_operator
+
+echo "PASS: Operator scaled down - deployment patches will not be reconciled"

--- a/tests/fixtures/chainsaw-tests/tls-profile/02-patch-modern.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/02-patch-modern.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# Patch the distributed-tracing deployment to use the Modern TLS profile (TLS 1.3 only).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+echo "============================================="
+echo "Step 2: Patch deployment for Modern TLS profile"
+echo "============================================="
+
+# Save baseline pod UID to verify restart
+BASELINE_UID=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.uid}')
+echo "Baseline pod UID: $BASELINE_UID"
+
+# Patch with TLS_MIN_VERSION=VersionTLS13
+patch_tls_env "VersionTLS13" ""
+
+# Verify the pod was restarted (new UID)
+NEW_UID=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.uid}')
+if [ "$NEW_UID" != "$BASELINE_UID" ]; then
+  echo "PASS: Pod restarted (UID changed: $BASELINE_UID -> $NEW_UID)"
+else
+  fail "Pod was not restarted after TLS env patch"
+fi
+
+# Verify the env var is set
+ENV_VALUE=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TLS_MIN_VERSION")].value}')
+if [ "$ENV_VALUE" != "VersionTLS13" ]; then
+  fail "TLS_MIN_VERSION env var not set correctly, got: $ENV_VALUE"
+fi
+
+echo "PASS: Deployment patched with TLS_MIN_VERSION=VersionTLS13"

--- a/tests/fixtures/chainsaw-tests/tls-profile/03-verify-modern.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/03-verify-modern.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify Modern TLS profile: only TLS 1.3 should be accepted, TLS 1.2 must be rejected.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+detect_fips
+
+echo "============================================="
+echo "Step 3: Verify Modern TLS profile (TLS 1.3 only)"
+echo "============================================="
+
+# --- 1. Verify TLS_MIN_VERSION env var is set ---
+echo "=== Checking TLS_MIN_VERSION env var ==="
+ENV_VALUE=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TLS_MIN_VERSION")].value}')
+if [ "$ENV_VALUE" != "VersionTLS13" ]; then
+  fail "TLS_MIN_VERSION env var expected VersionTLS13, got: $ENV_VALUE"
+fi
+echo "PASS: TLS_MIN_VERSION=VersionTLS13"
+
+# --- 2. nmap scan to verify Modern profile (TLS 1.3 only) ---
+verify_nmap_tls_profile "modern" "Modern profile"
+
+# --- 3. Verify TLS 1.2 connections are rejected ---
+verify_tls_version_rejected "-tls1_2" "TLS 1.2 rejected under Modern profile"
+
+# --- 4. Functional endpoint checks (via TLS 1.3) ---
+verify_all_endpoints "Modern profile"
+
+echo ""
+echo "============================================="
+echo "PASS: Modern TLS profile verified"
+echo "  - Only TLS 1.3 accepted"
+echo "  - TLS 1.2 correctly rejected"
+echo "  - All endpoints responding correctly"
+echo "============================================="

--- a/tests/fixtures/chainsaw-tests/tls-profile/04-patch-custom-ciphers.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/04-patch-custom-ciphers.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Patch the distributed-tracing deployment with custom cipher suites.
+# Uses TLS 1.2 with a restricted set of cipher suites.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+echo "============================================="
+echo "Step 4: Patch deployment for Custom cipher suites"
+echo "============================================="
+
+# Save baseline pod UID to verify restart
+BASELINE_UID=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.uid}')
+echo "Baseline pod UID: $BASELINE_UID"
+
+# Patch with specific cipher suites and TLS 1.2 min version
+CIPHER_SUITES="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+patch_tls_env "VersionTLS12" "$CIPHER_SUITES"
+
+# Verify the pod was restarted (new UID)
+NEW_UID=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.uid}')
+if [ "$NEW_UID" != "$BASELINE_UID" ]; then
+  echo "PASS: Pod restarted (UID changed: $BASELINE_UID -> $NEW_UID)"
+else
+  fail "Pod was not restarted after TLS env patch"
+fi
+
+# Verify env vars are set
+MIN_VER=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TLS_MIN_VERSION")].value}')
+CIPHER_VAL=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TLS_CIPHER_SUITES")].value}')
+
+if [ "$MIN_VER" != "VersionTLS12" ]; then
+  fail "TLS_MIN_VERSION expected VersionTLS12, got: $MIN_VER"
+fi
+if [ "$CIPHER_VAL" != "$CIPHER_SUITES" ]; then
+  fail "TLS_CIPHER_SUITES not set correctly, got: $CIPHER_VAL"
+fi
+
+echo "PASS: Deployment patched with custom TLS cipher suites"
+echo "  TLS_MIN_VERSION=$MIN_VER"
+echo "  TLS_CIPHER_SUITES=$CIPHER_VAL"

--- a/tests/fixtures/chainsaw-tests/tls-profile/05-verify-custom-ciphers.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/05-verify-custom-ciphers.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify custom cipher suite configuration:
+# - Only the specified cipher suites should be offered for TLS 1.2
+# - TLS 1.3 cipher suites are managed by Go and always available
+# - Endpoints must be functional
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+detect_fips
+
+echo "============================================="
+echo "Step 5: Verify Custom cipher suites"
+echo "============================================="
+
+# --- 1. Verify env vars are set correctly ---
+echo "=== Checking TLS env vars ==="
+MIN_VER=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TLS_MIN_VERSION")].value}')
+CIPHER_VAL=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TLS_CIPHER_SUITES")].value}')
+echo "TLS_MIN_VERSION=$MIN_VER"
+echo "TLS_CIPHER_SUITES=$CIPHER_VAL"
+
+# --- 2. nmap scan to check cipher suites offered ---
+PLUGIN_IP=$(get_plugin_pod_ip)
+echo "=== nmap ssl-enum-ciphers scan ($PLUGIN_IP:$PLUGIN_PORT) ==="
+NMAP_RESULT=$(kubectl exec tls-scanner -n "$NAMESPACE" -- \
+  nmap -Pn --script ssl-enum-ciphers -p "$PLUGIN_PORT" "$PLUGIN_IP")
+echo "$NMAP_RESULT"
+
+PORT_SECTION=$(echo "$NMAP_RESULT" | grep -A 100 "${PLUGIN_PORT}/tcp" || true)
+if [ -z "$PORT_SECTION" ]; then
+  fail "Port $PLUGIN_PORT not found in nmap output"
+fi
+
+# --- 3. Verify TLS 1.2 section contains only allowed cipher suites ---
+echo "=== Verifying TLS 1.2 cipher suites ==="
+TLS12_SECTION=$(echo "$PORT_SECTION" | sed -n '/TLSv1.2/,/TLSv1.3\|least strength/p' || true)
+
+if [ -n "$TLS12_SECTION" ]; then
+  echo "TLS 1.2 section found:"
+  echo "$TLS12_SECTION"
+
+  # Check for the expected cipher suites
+  echo "$TLS12_SECTION" | grep -i "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" \
+    || fail "Expected cipher TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 not found in TLS 1.2"
+  echo "$TLS12_SECTION" | grep -i "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" \
+    || fail "Expected cipher TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 not found in TLS 1.2"
+  echo "PASS: Both expected cipher suites present in TLS 1.2"
+
+  # Verify no other cipher suites are present in TLS 1.2
+  # Extract cipher names from nmap output (lines contain TLS_ECDHE or TLS_RSA etc.)
+  # nmap lines look like: |       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
+  FOUND_CIPHERS=$(echo "$TLS12_SECTION" | grep -oE 'TLS_[A-Z0-9_]+' | grep -v '^TLSv' | sort -u || true)
+  echo "Found TLS 1.2 ciphers: $FOUND_CIPHERS"
+
+  echo "$FOUND_CIPHERS" | while IFS= read -r cipher; do
+    [ -z "$cipher" ] && continue
+    if ! echo "$cipher" | grep -qE "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"; then
+      fail "Unexpected TLS 1.2 cipher suite found: $cipher"
+    fi
+  done
+  echo "PASS: No unexpected TLS 1.2 cipher suites found"
+else
+  echo "NOTE: No TLS 1.2 section found - this may happen if Go only offers TLS 1.3 ciphers"
+fi
+
+# --- 4. Verify TLS 1.3 is still available ---
+echo "=== Verifying TLS 1.3 availability ==="
+echo "$PORT_SECTION" | grep "TLSv1.3" || fail "TLS 1.3 should still be available"
+echo "PASS: TLS 1.3 is available"
+
+# --- 5. Functional endpoint checks ---
+verify_all_endpoints "Custom cipher suites"
+
+echo ""
+echo "============================================="
+echo "PASS: Custom cipher suite configuration verified"
+echo "  - Only specified TLS 1.2 cipher suites offered"
+echo "  - TLS 1.3 still available"
+echo "  - All endpoints responding correctly"
+echo "============================================="

--- a/tests/fixtures/chainsaw-tests/tls-profile/06-patch-old.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/06-patch-old.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Patch the distributed-tracing deployment to use the Old TLS profile (TLS 1.0+).
+# Note: Go 1.22+ removed support for TLS 1.0 and 1.1, so the effective minimum
+# will be TLS 1.2. This test verifies the configuration is accepted and the server
+# still functions correctly.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+echo "============================================="
+echo "Step 6: Patch deployment for Old TLS profile"
+echo "============================================="
+
+# Save baseline pod UID to verify restart
+BASELINE_UID=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.uid}')
+echo "Baseline pod UID: $BASELINE_UID"
+
+# Patch with TLS_MIN_VERSION=VersionTLS10 (Old profile)
+# Note: Go 1.22+ will still enforce TLS 1.2 as minimum, but the config should be accepted
+patch_tls_env "VersionTLS10" ""
+
+# Verify the pod was restarted (new UID)
+NEW_UID=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.uid}')
+if [ "$NEW_UID" != "$BASELINE_UID" ]; then
+  echo "PASS: Pod restarted (UID changed: $BASELINE_UID -> $NEW_UID)"
+else
+  fail "Pod was not restarted after TLS env patch"
+fi
+
+# Verify the env var is set
+ENV_VALUE=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TLS_MIN_VERSION")].value}')
+if [ "$ENV_VALUE" != "VersionTLS10" ]; then
+  fail "TLS_MIN_VERSION env var not set correctly, got: $ENV_VALUE"
+fi
+
+echo "PASS: Deployment patched with TLS_MIN_VERSION=VersionTLS10 (Old profile)"

--- a/tests/fixtures/chainsaw-tests/tls-profile/07-verify-old.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/07-verify-old.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify Old TLS profile: TLS 1.0+ configured.
+# Note: Go 1.22+ dropped TLS 1.0 and 1.1 support, so even with VersionTLS10 configured,
+# the effective minimum is TLS 1.2. This test verifies:
+# - The configuration is accepted without errors
+# - TLS 1.2 and TLS 1.3 are both available
+# - Endpoints are functional
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+detect_fips
+
+echo "============================================="
+echo "Step 7: Verify Old TLS profile"
+echo "============================================="
+
+# --- 1. Verify TLS_MIN_VERSION env var is set ---
+echo "=== Checking TLS_MIN_VERSION env var ==="
+ENV_VALUE=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TLS_MIN_VERSION")].value}')
+if [ "$ENV_VALUE" != "VersionTLS10" ]; then
+  fail "TLS_MIN_VERSION env var expected VersionTLS10, got: $ENV_VALUE"
+fi
+echo "PASS: TLS_MIN_VERSION=VersionTLS10"
+
+# --- 2. Verify the pod is running (config was accepted, no crash) ---
+echo "=== Verifying pod is running ==="
+POD_PHASE=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].status.phase}')
+if [ "$POD_PHASE" != "Running" ]; then
+  fail "Pod is not running (phase: $POD_PHASE) - Old TLS config may have caused a crash"
+fi
+echo "PASS: Pod is running with Old TLS configuration"
+
+# --- 3. nmap scan to verify TLS versions ---
+verify_nmap_tls_profile "old" "Old profile"
+
+# --- 4. Functional endpoint checks ---
+verify_all_endpoints "Old profile"
+
+echo ""
+echo "============================================="
+echo "PASS: Old TLS profile verified"
+echo "  - Configuration accepted without errors"
+echo "  - TLS 1.2 and TLS 1.3 available"
+echo "  - All endpoints responding correctly"
+echo "============================================="

--- a/tests/fixtures/chainsaw-tests/tls-profile/08-revert-default.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/08-revert-default.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Revert the distributed-tracing deployment to the default TLS configuration
+# by removing all TLS environment variables. Verify Intermediate profile is restored.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/tls-helpers.sh"
+
+detect_fips
+
+echo "============================================="
+echo "Step 8: Revert to default and verify Intermediate"
+echo "============================================="
+
+# Save baseline pod UID
+BASELINE_UID=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.uid}')
+echo "Baseline pod UID: $BASELINE_UID"
+
+# Remove TLS env vars
+remove_tls_env
+
+# Verify the pod was restarted
+NEW_UID=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.uid}')
+if [ "$NEW_UID" != "$BASELINE_UID" ]; then
+  echo "PASS: Pod restarted (UID changed: $BASELINE_UID -> $NEW_UID)"
+else
+  echo "NOTE: Pod UID unchanged - deployment may not have changed"
+fi
+
+# Verify no TLS env vars remain
+CONTAINER_ENV=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env}' 2>/dev/null || echo "null")
+if [ "$CONTAINER_ENV" != "" ] && [ "$CONTAINER_ENV" != "null" ]; then
+  if echo "$CONTAINER_ENV" | grep -q "TLS_MIN_VERSION\|TLS_CIPHER_SUITES"; then
+    fail "TLS env vars still present after revert"
+  fi
+fi
+echo "PASS: TLS env vars removed"
+
+# Verify Intermediate profile is restored
+verify_nmap_tls_profile "intermediate" "Reverted to Intermediate profile"
+
+# Verify endpoints
+verify_all_endpoints "Reverted Intermediate profile"
+
+# Scale the operator back up so it resumes managing the deployment
+scale_up_operator
+
+# Give the operator a moment to reconcile, then verify the deployment is still healthy
+sleep 10
+kubectl wait --for=condition=Ready pods -l "$LABEL_SELECTOR" -n "$NAMESPACE" --timeout=120s
+
+echo ""
+echo "============================================="
+echo "PASS: Successfully reverted to default Intermediate profile"
+echo "  - TLS env vars removed"
+echo "  - TLS 1.2 and TLS 1.3 both supported"
+echo "  - All endpoints responding correctly"
+echo "  - Observability operator scaled back up"
+echo "============================================="

--- a/tests/fixtures/chainsaw-tests/tls-profile/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile/chainsaw-test.yaml
@@ -1,0 +1,132 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: tls-profile
+spec:
+  steps:
+  - name: Detect COO namespace
+    try:
+    - command:
+        entrypoint: oc
+        args:
+        - get
+        - deployment
+        - -A
+        - -l app.kubernetes.io/name=observability-operator
+        - -o
+        - jsonpath={.items[0].metadata.namespace}
+        outputs:
+        - name: COO_NAMESPACE
+          value: ($stdout)
+
+  - name: Install tls-scanner
+    try:
+    - apply:
+        file: 00-install-tls-scanner.yaml
+    - assert:
+        file: 00-assert.yaml
+
+  - name: Verify default Intermediate TLS profile
+    try:
+    - script:
+        timeout: 5m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./01-verify-default-intermediate.sh
+
+  # Scale down the observability-operator so it does not reconcile away
+  # manual env-var patches on the plugin deployment.
+  - name: Scale down observability-operator
+    try:
+    - script:
+        timeout: 2m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./01a-scale-down-operator.sh
+
+  - name: Patch deployment for Modern TLS profile
+    try:
+    - script:
+        timeout: 5m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./02-patch-modern.sh
+
+  - name: Verify Modern TLS profile
+    try:
+    - script:
+        timeout: 5m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./03-verify-modern.sh
+
+  - name: Patch deployment with custom cipher suites
+    try:
+    - script:
+        timeout: 5m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./04-patch-custom-ciphers.sh
+
+  - name: Verify custom cipher suites
+    try:
+    - script:
+        timeout: 5m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./05-verify-custom-ciphers.sh
+
+  - name: Patch deployment for Old TLS profile
+    try:
+    - script:
+        timeout: 5m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./06-patch-old.sh
+
+  - name: Verify Old TLS profile
+    try:
+    - script:
+        timeout: 5m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./07-verify-old.sh
+
+  - name: Revert to default and verify Intermediate profile restored
+    try:
+    - script:
+        timeout: 5m
+        env:
+        - name: NAMESPACE
+          value: ($COO_NAMESPACE)
+        content: ./08-revert-default.sh
+
+  # Cleanup: always revert deployment and remove tls-scanner resources
+  catch:
+  - script:
+      timeout: 3m
+      content: |
+        NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+          -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "openshift-cluster-observability-operator")
+        DEPLOYMENT="distributed-tracing"
+        # Revert TLS env vars
+        kubectl patch deployment "$DEPLOYMENT" -n "$NAMESPACE" --type=json \
+          -p '[{"op": "remove", "path": "/spec/template/spec/containers/0/env"}]' 2>/dev/null || true
+        kubectl rollout status deployment/"$DEPLOYMENT" -n "$NAMESPACE" --timeout=120s || true
+        # Scale operator back up
+        kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=1 2>/dev/null || true
+        kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=120s || true
+        # Remove tls-scanner resources
+        kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+        kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+        kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+        kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+        kubectl delete sa tls-scanner -n "$NAMESPACE" 2>/dev/null || true

--- a/tests/fixtures/chainsaw-tests/tls-profile/tls-helpers.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/tls-helpers.sh
@@ -1,0 +1,257 @@
+#!/bin/sh
+# Common TLS verification helpers for the distributed-tracing-console-plugin.
+# Sourced by each verification script.
+
+# Auto-detect the COO namespace from the operator deployment (works even when scaled to 0).
+NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+  -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "openshift-cluster-observability-operator")
+echo "Using COO namespace: $NAMESPACE"
+DEPLOYMENT="distributed-tracing"
+OPERATOR_DEPLOYMENT="observability-operator"
+PLUGIN_PORT="9443"
+LABEL_SELECTOR="app.kubernetes.io/instance=distributed-tracing"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Scale down the observability-operator to prevent it from reconciling the
+# plugin deployment while we patch TLS env vars for testing.
+scale_down_operator() {
+  echo "=== Scaling down $OPERATOR_DEPLOYMENT to prevent reconciliation ==="
+  kubectl scale deployment "$OPERATOR_DEPLOYMENT" -n "$NAMESPACE" --replicas=0
+  kubectl rollout status deployment/"$OPERATOR_DEPLOYMENT" -n "$NAMESPACE" --timeout=60s
+  echo "PASS: $OPERATOR_DEPLOYMENT scaled to 0"
+}
+
+# Scale the observability-operator back up.
+scale_up_operator() {
+  echo "=== Scaling up $OPERATOR_DEPLOYMENT ==="
+  kubectl scale deployment "$OPERATOR_DEPLOYMENT" -n "$NAMESPACE" --replicas=1
+  kubectl rollout status deployment/"$OPERATOR_DEPLOYMENT" -n "$NAMESPACE" --timeout=120s
+  kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=observability-operator \
+    -n "$NAMESPACE" --timeout=120s
+  echo "PASS: $OPERATOR_DEPLOYMENT scaled back to 1"
+}
+
+# Detect FIPS mode from machineconfig
+detect_fips() {
+  IS_FIPS=false
+  if kubectl get machineconfig 99-master-fips -o jsonpath='{.spec.fips}' 2>/dev/null | grep -q true; then
+    IS_FIPS=true
+    echo "FIPS mode detected - adjusting TLS verification"
+  fi
+}
+
+# Get the pod IP of the distributed-tracing plugin pod.
+get_plugin_pod_ip() {
+  kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].status.podIP}'
+}
+
+# Get the plugin pod name.
+get_plugin_pod_name() {
+  kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.name}'
+}
+
+# Wait for the deployment rollout to complete.
+wait_for_rollout() {
+  echo "Waiting for deployment rollout..."
+  kubectl rollout status deployment/"$DEPLOYMENT" -n "$NAMESPACE" --timeout=120s
+  # Wait for old pods to terminate before checking readiness
+  sleep 10
+  kubectl wait --for=condition=Ready pods -l "$LABEL_SELECTOR" -n "$NAMESPACE" --timeout=120s
+}
+
+# Patch the deployment with TLS environment variables.
+# Args: $1=TLS_MIN_VERSION value (optional), $2=TLS_CIPHER_SUITES value (optional)
+patch_tls_env() {
+  local min_version="${1:-}"
+  local cipher_suites="${2:-}"
+
+  local env_patch='[]'
+
+  if [ -n "$min_version" ]; then
+    env_patch=$(echo "$env_patch" | jq --arg v "$min_version" '. + [{"name": "TLS_MIN_VERSION", "value": $v}]')
+  fi
+
+  if [ -n "$cipher_suites" ]; then
+    env_patch=$(echo "$env_patch" | jq --arg v "$cipher_suites" '. + [{"name": "TLS_CIPHER_SUITES", "value": $v}]')
+  fi
+
+  echo "Patching deployment with env: $env_patch"
+  kubectl patch deployment "$DEPLOYMENT" -n "$NAMESPACE" --type=json \
+    -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env\", \"value\": $env_patch}]"
+
+  wait_for_rollout
+}
+
+# Remove all TLS environment variables from the deployment (revert to default).
+remove_tls_env() {
+  echo "Removing TLS environment variables from deployment..."
+  kubectl patch deployment "$DEPLOYMENT" -n "$NAMESPACE" --type=json \
+    -p '[{"op": "remove", "path": "/spec/template/spec/containers/0/env"}]' 2>/dev/null || true
+
+  wait_for_rollout
+}
+
+# Verify TLS profile via direct nmap ssl-enum-ciphers scan on the plugin pod IP.
+# Args: $1=expected_profile (intermediate|modern|old|custom), $2=description
+#       $3=expected_ciphers (optional, comma-separated cipher names for custom profile)
+verify_nmap_tls_profile() {
+  local ip
+  ip=$(get_plugin_pod_ip)
+  local expected="$1" description="$2" expected_ciphers="${3:-}"
+
+  echo "=== nmap ssl-enum-ciphers: $description ($ip port $PLUGIN_PORT) ==="
+  local result
+  result=$(kubectl exec tls-scanner -n "$NAMESPACE" -- nmap -Pn --script ssl-enum-ciphers -p "$PLUGIN_PORT" "$ip")
+  echo "$result"
+
+  # On FIPS clusters, retry with explicit FIPS cipher list if no TLS detected
+  if [ "$IS_FIPS" = "true" ] && ! echo "$result" | grep -q "TLSv1"; then
+    echo "FIPS: Initial scan found no TLS, retrying with FIPS ciphers..."
+    result=$(kubectl exec tls-scanner -n "$NAMESPACE" -- nmap -Pn --script ssl-enum-ciphers \
+      --script-args "ssl-enum-ciphers.ciphersuite=TLSv1.3+AES_128_GCM_SHA256:TLSv1.3+AES_256_GCM_SHA384" \
+      -p "$PLUGIN_PORT" "$ip")
+    echo "$result"
+  fi
+
+  local port_section
+  port_section=$(echo "$result" | grep -A 100 "${PLUGIN_PORT}/tcp" || true)
+  if [ -z "$port_section" ]; then
+    fail "$description: port $PLUGIN_PORT not found in nmap output"
+  fi
+
+  case "$expected" in
+    intermediate)
+      echo "$port_section" | grep "TLSv1.2" || fail "$description: port $PLUGIN_PORT missing TLSv1.2"
+      echo "$port_section" | grep "TLSv1.3" || fail "$description: port $PLUGIN_PORT missing TLSv1.3"
+      # Ensure TLS 1.0 and 1.1 are not present
+      if echo "$port_section" | grep -q "TLSv1.0"; then
+        fail "$description: port $PLUGIN_PORT unexpectedly accepting TLSv1.0"
+      fi
+      if echo "$port_section" | grep -q "TLSv1.1"; then
+        fail "$description: port $PLUGIN_PORT unexpectedly accepting TLSv1.1"
+      fi
+      ;;
+    modern)
+      echo "$port_section" | grep "TLSv1.3" || fail "$description: port $PLUGIN_PORT missing TLSv1.3"
+      if echo "$port_section" | head -30 | grep -q "TLSv1.2"; then
+        fail "$description: port $PLUGIN_PORT still accepting TLSv1.2 under Modern profile"
+      fi
+      ;;
+    old)
+      # Old profile accepts TLS 1.0+. At minimum TLS 1.2 and 1.3 must be present.
+      echo "$port_section" | grep "TLSv1.2" || fail "$description: port $PLUGIN_PORT missing TLSv1.2"
+      echo "$port_section" | grep "TLSv1.3" || fail "$description: port $PLUGIN_PORT missing TLSv1.3"
+      # TLS 1.0 or 1.1 should also be present for Old profile
+      if ! echo "$port_section" | grep -q "TLSv1.0" && ! echo "$port_section" | grep -q "TLSv1.1"; then
+        echo "NOTE: Old profile expected TLS 1.0/1.1 but not found (Go may not support them) - continuing"
+      fi
+      ;;
+    custom)
+      # Just verify TLS is working; cipher verification is done separately
+      echo "$port_section" | grep "TLSv1" || fail "$description: no TLS detected on port $PLUGIN_PORT"
+      ;;
+  esac
+
+  # Verify specific cipher suites if provided
+  if [ -n "$expected_ciphers" ]; then
+    for cipher in ${expected_ciphers//,/ }; do
+      echo "$port_section" | grep -i "$cipher" || fail "$description: expected cipher $cipher not found"
+    done
+  fi
+
+  echo "PASS: $description (port $PLUGIN_PORT, profile=$expected)"
+}
+
+# Verify that a specific TLS version is rejected by the server.
+# Uses openssl s_client to attempt a connection with a restricted TLS version.
+# Args: $1=tls_version_flag (e.g. -tls1_2), $2=description
+verify_tls_version_rejected() {
+  local ip
+  ip=$(get_plugin_pod_ip)
+  local tls_flag="$1" description="$2"
+
+  echo "=== Verify TLS version rejected: $description ($ip:$PLUGIN_PORT $tls_flag) ==="
+  local result
+  result=$(kubectl exec tls-scanner -n "$NAMESPACE" -- \
+    timeout 10 openssl s_client -connect "$ip:$PLUGIN_PORT" "$tls_flag" </dev/null 2>&1) || true
+  echo "$result"
+
+  if echo "$result" | grep -qi "CONNECTED.*SSL" && echo "$result" | grep -qi "Protocol.*:.*TLS"; then
+    # Check if the handshake actually succeeded
+    if ! echo "$result" | grep -qi "handshake failure\|wrong version\|alert protocol\|ssl alert\|routines:ssl"; then
+      fail "$description: TLS connection should have been rejected but succeeded"
+    fi
+  fi
+
+  echo "PASS: $description - connection correctly rejected"
+}
+
+# Verify functional endpoint accessibility via curl from inside the cluster.
+# Args: $1=endpoint_path, $2=expected_status_code, $3=description
+verify_endpoint() {
+  local endpoint="$1" expected_code="$2" description="$3"
+  local svc_url="https://distributed-tracing.${NAMESPACE}.svc:9443${endpoint}"
+
+  echo "=== Endpoint check: $description ($svc_url) ==="
+  local http_code
+  http_code=$(kubectl exec tls-scanner -n "$NAMESPACE" -- \
+    curl -sk -o /dev/null -w '%{http_code}' "$svc_url" 2>&1)
+
+  if [ "$http_code" != "$expected_code" ]; then
+    fail "$description: expected HTTP $expected_code, got HTTP $http_code"
+  fi
+
+  echo "PASS: $description (HTTP $http_code)"
+}
+
+# Verify that all plugin endpoints respond correctly.
+verify_all_endpoints() {
+  local description="${1:-Plugin endpoints}"
+  echo "=== Verifying all plugin endpoints: $description ==="
+
+  verify_endpoint "/health" "200" "$description - /health"
+  verify_endpoint "/features" "200" "$description - /features"
+  verify_endpoint "/plugin-manifest.json" "200" "$description - /plugin-manifest.json"
+
+  echo "PASS: All endpoints verified for $description"
+}
+
+# Verify that nmap shows only specific cipher suites (no unexpected ones).
+# Args: $1=allowed_ciphers (pipe-separated for grep), $2=description
+verify_cipher_suites_exclusive() {
+  local ip
+  ip=$(get_plugin_pod_ip)
+  local allowed_pattern="$1" description="$2"
+
+  echo "=== Verify cipher suites exclusive: $description ==="
+  local result
+  result=$(kubectl exec tls-scanner -n "$NAMESPACE" -- nmap -Pn --script ssl-enum-ciphers -p "$PLUGIN_PORT" "$ip")
+  echo "$result"
+
+  local port_section
+  port_section=$(echo "$result" | grep -A 100 "${PLUGIN_PORT}/tcp" || true)
+  if [ -z "$port_section" ]; then
+    fail "$description: port $PLUGIN_PORT not found in nmap output"
+  fi
+
+  # Extract cipher names from nmap output (lines starting with TLS_ or containing cipher suite names)
+  local found_ciphers
+  found_ciphers=$(echo "$port_section" | grep "TLS_" | awk '{print $1}' | sort -u || true)
+
+  if [ -z "$found_ciphers" ]; then
+    fail "$description: no cipher suites found in nmap output"
+  fi
+
+  echo "Found cipher suites:"
+  echo "$found_ciphers"
+
+  # Verify each found cipher is in the allowed list
+  echo "$found_ciphers" | while IFS= read -r cipher; do
+    if ! echo "$cipher" | grep -qE "$allowed_pattern"; then
+      fail "$description: unexpected cipher suite found: $cipher"
+    fi
+  done
+
+  echo "PASS: $description - only allowed cipher suites present"
+}

--- a/tests/views/operator-hub-page.ts
+++ b/tests/views/operator-hub-page.ts
@@ -7,6 +7,7 @@ export const operatorHubPage = {
       `/operatorhub/subscribe?pkg=${operatorName}&catalog=${csName}&catalogNamespace=openshift-marketplace`,
     );
     cy.get('body').should('be.visible');
+    cy.dismissWelcomeModal();
 
     // Wait for page to fully load - look for install button as a sign the page is ready
     cy.get('[data-test="install-operator"]').should('be.visible');
@@ -28,19 +29,19 @@ export const operatorHubPage = {
       // Step 1: Click "Select a Namespace" radio button (this shows the dropdown)
       cy.get('input[data-test="Select a Namespace-radio-input"]').should('be.visible');
       cy.get('input[data-test="Select a Namespace-radio-input"]').click();
-      
+
       // Step 2: Wait for "Select Project" dropdown to appear and click it
       cy.get('[data-test="dropdown-selectbox"]').should('be.visible').click();
-      
+
       // Step 3: Click "Create Project" button
       cy.get('button[data-test-dropdown-menu="Create_Project"]').click();
-      
+
       // Step 4: Fill in the project name in the modal
       cy.get('input[data-test="input-name"]').should('be.visible').clear().type(installNamespace);
-      
+
       // Step 5: Click Create button to create the project
       cy.get('[data-test="confirm-action"]').click();
-      
+
       // Step 6: Wait for Install button to be available after namespace creation
       cy.get('[data-test="install-operator"]', { timeout: 60000 }).should('be.visible');
     } else {
@@ -70,11 +71,11 @@ export const operatorHubPage = {
           cy.get('[data-test="Operator recommended Namespace:-radio-input"]').click();
         }
       });
-      
+
       // Enable monitoring checkbox if it exists (only for recommended namespace)
       helperfuncs.clickIfExist('[data-test="enable-monitoring"]');
     }
-    
+
     // Final step: Click Install button
     cy.get('[data-test="install-operator"]').should('be.visible').click();
   },

--- a/tests/views/tour.ts
+++ b/tests/views/tour.ts
@@ -8,6 +8,19 @@ export const guidedTour = {
           .first()
           .click();
       }
+      // OCP 4.22+ modal overlays (e.g. "Welcome to the new OpenShift experience!")
+      if ($body.find('.pf-v6-c-modal-box, .pf-v5-c-modal-box').length > 0) {
+        if ($body.find('.pf-v6-c-modal-box button[aria-label="Close"], .pf-v5-c-modal-box button[aria-label="Close"]').length > 0) {
+          cy.get('.pf-v6-c-modal-box button[aria-label="Close"], .pf-v5-c-modal-box button[aria-label="Close"]')
+            .first()
+            .click({ force: true });
+        } else {
+          cy.get('.pf-v6-c-modal-box button, .pf-v5-c-modal-box button')
+            .not(':contains("Learn")')
+            .first()
+            .click({ force: true });
+        }
+      }
     });
   },
   isOpen: () => {


### PR DESCRIPTION
Cherry-pick of #261 to `release-coo-ocp-4.15`.

## Changes
- Wire `GetConfigForClient` so every TLS handshake uses the dynamically reloaded cert instead of the static cert loaded by `ListenAndServeTLS`
- Start the file watcher that detects cert rotation and notifies the controller
- Add cert-rotation chainsaw tests
- Sync `tests/` directory to match main branch (adds tls-profile chainsaw tests and updated e2e tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)