### PR TITLE
NO-JIRA: [release-coo-ocp-4.22] fix: wire dynamic TLS cert reload and add cert-rotation tests

### DIFF
--- a/pkg/server.go
+++ b/pkg/server.go
@@ -123,8 +123,16 @@ func Start(cfg *Config) {
 			logrus.WithError(err).Fatal("invalid certificate/key files")
 		}
 
+		// Wire GetConfigForClient so every TLS handshake uses the dynamically
+		// reloaded cert instead of the static cert loaded by ListenAndServeTLS.
+		tlsConfig.GetConfigForClient = ctrl.GetConfigForClient
+		// Notify the controller whenever the cert/key files change on disk.
+		certKeyPair.AddListener(ctrl)
+
 		ctx := context.Background()
 		go ctrl.Run(1, ctx.Done())
+		// Start the file watcher that detects cert rotation and notifies the controller.
+		go certKeyPair.Run(ctx, 1)
 	}
 
 	httpServer := &http.Server{

--- a/pkg/server_test.go
+++ b/pkg/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -16,6 +17,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -465,8 +467,112 @@ func TestSecureServerCipherSuites(t *testing.T) {
 	require.Error(t, err, "Client with non-matching cipher suite should be rejected")
 }
 
+// TestSecureServerCertRotation verifies that the server dynamically reloads its
+// TLS certificate when the cert/key files are replaced on disk, without a pod
+// restart. This is the regression test for the cert-rotation bug where
+// GetConfigForClient, AddListener, and certKeyPair.Run were not wired up,
+// causing the server to serve the initial static cert forever.
+//
+// The test intentionally connects by IP (no SNI) to exercise the non-SNI code
+// path in GetConfigForClient — exactly the path the original bug exposed.
+func TestSecureServerCertRotation(t *testing.T) {
+	testPort, err := getFreePort(testHostname)
+	require.NoError(t, err)
+
+	tmpDir, err := os.MkdirTemp("", "server-test-cert-rotation")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	certFile := filepath.Join(tmpDir, "server.cert")
+	keyFile := filepath.Join(tmpDir, "server.key")
+	testServerHostPort := fmt.Sprintf("%v:%v", testHostname, testPort)
+
+	err = generateCertificate(t, certFile, keyFile, testServerHostPort)
+	require.NoError(t, err)
+
+	// Save the working directory so we can restore it after the test.
+	// prepareServerAssets calls os.Chdir; without restoring, subsequent tests
+	// that use relative paths (e.g. TestFilesHandler → http.Dir("testdata"))
+	// would run from the deleted tmpDir and fail.
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	tmpDirAssets := prepareServerAssets(t)
+	defer func() {
+		os.RemoveAll(tmpDirAssets)
+		os.Chdir(originalDir) //nolint:errcheck
+	}()
+
+	go func() {
+		Start(&Config{
+			CertFile:       certFile,
+			PrivateKeyFile: keyFile,
+			Port:           testPort,
+		})
+	}()
+
+	serverURL := fmt.Sprintf("https://%s", testServerHostPort)
+	httpClient, err := (&httpClientConfig{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+	}).buildHTTPClient()
+	require.NoError(t, err)
+
+	checkHTTPReady(httpClient, serverURL+"/health")
+
+	initialSerial, err := getServedCertSerial(testHostname, testPort)
+	require.NoError(t, err)
+	t.Logf("Initial cert serial: %X", initialSerial)
+
+	// Replace the cert/key files on disk to simulate certificate rotation.
+	err = generateCertificate(t, certFile, keyFile, testServerHostPort)
+	require.NoError(t, err)
+	t.Logf("Cert/key files replaced on disk")
+
+	// Poll until the server begins serving the new cert. The dynamic controller
+	// detects the file change via fsnotify and reloads within a few seconds.
+	var rotatedSerial *big.Int
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		serial, dialErr := getServedCertSerial(testHostname, testPort)
+		if dialErr == nil && serial.Cmp(initialSerial) != 0 {
+			rotatedSerial = serial
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	require.NotNil(t, rotatedSerial, "server must serve the new cert within 30s of file replacement")
+	t.Logf("Rotated cert serial: %X", rotatedSerial)
+
+	_, err = getRequestResults(t, httpClient, serverURL+"/health")
+	require.NoError(t, err, "server must remain healthy after cert rotation")
+}
+
+// getServedCertSerial dials the TLS server at host:port and returns the serial
+// number of the presented leaf certificate. Connecting by IP without a
+// server-name hint (no SNI) is intentional — this exercises the code path in
+// DynamicServingCertificateController.GetConfigForClient that selects the cert
+// for clients that omit SNI, which is exactly how in-cluster scanners connect
+// to a pod IP directly.
+func getServedCertSerial(host string, port int) (*big.Int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	dialer := tls.Dialer{Config: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+	conn, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	certs := conn.(*tls.Conn).ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no peer certificates presented")
+	}
+	return certs[0].SerialNumber, nil
+}
+
 func TestFilesHandler(t *testing.T) {
-	fs := http.Dir("testdata")
+	_, thisFile, _, _ := runtime.Caller(0)
+	fs := http.Dir(filepath.Join(filepath.Dir(thisFile), "testdata"))
 	handler := filesHandler(fs)
 
 	req := httptest.NewRequest("GET", "/index.html", nil)

--- a/tests/e2e/dt-plugin-tests.cy.ts
+++ b/tests/e2e/dt-plugin-tests.cy.ts
@@ -1202,6 +1202,10 @@ EOF`,
     cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');
   });
 
+  it('[Capability:UIPlugin][Capability:TLSCertRotation] Test dynamic TLS certificate rotation without pod restart', function () {
+    cy.runChainsawTest('cert-rotation', 'TLS certificate rotation', { timeout: 600000 });
+  });
+
   it('[Capability:UIPlugin][Capability:TLSProfile] Test TLS profile configuration on plugin endpoints', function () {
     // Setup: install tls-scanner and scale down operator
     cy.runChainsawTest('tls-profile-setup', 'TLS profile setup');

--- a/tests/fixtures/chainsaw-tests/cert-rotation/00-assert.yaml
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+status:
+  phase: Running

--- a/tests/fixtures/chainsaw-tests/cert-rotation/00-install-tls-scanner.yaml
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/00-install-tls-scanner.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-scanner-pods-reader-dt-plugin
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-scanner-pods-reader-dt-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-scanner-pods-reader-dt-plugin
+subjects:
+- kind: ServiceAccount
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: tls-scanner-scc-dt-plugin
+allowPrivilegedContainer: false
+allowPrivilegeEscalation: false
+allowHostNetwork: false
+allowHostPorts: false
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+  seLinuxOptions:
+    type: spc_t
+seccompProfiles:
+- 'runtime/default'
+users:
+- (join(':', ['system:serviceaccount', $COO_NAMESPACE, 'tls-scanner']))
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tls-scanner
+  namespace: ($COO_NAMESPACE)
+  labels:
+    app: tls-scanner
+spec:
+  serviceAccountName: tls-scanner
+  containers:
+  - name: tls-scanner
+    image: quay.io/rhn_support_ikanse/tls-scanner@sha256:3f354b5f3f76a62f3e34edea3361ce79b4f010df1633d03f92e89f6a7a6f1f0b
+    command: ["sleep", "infinity"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  restartPolicy: Never

--- a/tests/fixtures/chainsaw-tests/cert-rotation/01-cert-rotation.sh
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/01-cert-rotation.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Verify that the distributed-tracing-console-plugin backend dynamically reloads
+# its TLS certificate after the serving secret is rotated, without a pod restart.
+#
+# Regression test for: GetConfigForClient / AddListener / certKeyPair.Run were
+# not wired up, so the server served its initial cert forever even after the
+# cert file on disk changed.
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+  -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "openshift-cluster-observability-operator")}"
+
+DEPLOYMENT="distributed-tracing"
+PLUGIN_PORT="9443"
+LABEL_SELECTOR="app.kubernetes.io/instance=distributed-tracing"
+SECRET_NAME="distributed-tracing"
+CERT_MOUNT_PATH="/var/serving-cert/tls.crt"
+
+fail() { echo "FAIL: $*"; exit 1; }
+
+openssl_serial() {
+  local ip="$1"
+  kubectl exec tls-scanner -n "$NAMESPACE" -- bash -c \
+    "echo '' | timeout 10 openssl s_client -connect ${ip}:${PLUGIN_PORT} 2>/dev/null \
+     | openssl x509 -noout -serial 2>/dev/null" 2>/dev/null || echo ""
+}
+
+echo "Using namespace: $NAMESPACE"
+echo "Deployment: $DEPLOYMENT"
+
+# ---------------------------------------------------------------------------
+# Step 1: Record pre-rotation state
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 1: Pre-rotation state ==="
+
+OLD_SECRET_SERIAL=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -serial 2>/dev/null)
+echo "Secret cert serial (pre-rotation):  $OLD_SECRET_SERIAL"
+
+# Capture the concrete pod name and IP once; reuse throughout the test so all
+# checks reference the same pod even if the label selector matches multiple pods.
+POD_NAME=$(kubectl get pod -n "$NAMESPACE" -l "$LABEL_SELECTOR" \
+  --field-selector=status.phase=Running \
+  -o jsonpath='{.items[0].metadata.name}')
+[ -n "$POD_NAME" ] || fail "could not find a Running plugin pod"
+
+PLUGIN_IP=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.status.podIP}')
+[ -n "$PLUGIN_IP" ] || fail "could not get IP of pod $POD_NAME"
+
+POD_TS=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.creationTimestamp}')
+
+OLD_SERVED_SERIAL=$(openssl_serial "$PLUGIN_IP")
+echo "Served cert serial (pre-rotation):  ${OLD_SERVED_SERIAL:-<unavailable>}"
+echo "Plugin pod: $POD_NAME (created: $POD_TS)"
+
+# ---------------------------------------------------------------------------
+# Step 2: Delete secret — service-ca regenerates it with a new cert
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 2: Rotate the TLS secret ==="
+kubectl delete secret "$SECRET_NAME" -n "$NAMESPACE"
+echo "Secret deleted — waiting for service-ca to regenerate..."
+
+ELAPSED=0; TIMEOUT=120
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" &>/dev/null && break
+  sleep 2; ELAPSED=$((ELAPSED + 2))
+done
+[ $ELAPSED -lt $TIMEOUT ] || fail "secret not regenerated within ${TIMEOUT}s"
+echo "Secret regenerated after ~${ELAPSED}s"
+
+NEW_SECRET_SERIAL=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -serial 2>/dev/null)
+echo "Secret cert serial (post-rotation): $NEW_SECRET_SERIAL"
+
+[ "$OLD_SECRET_SERIAL" != "$NEW_SECRET_SERIAL" ] \
+  || fail "serial unchanged after secret regeneration — service-ca may not have rotated the cert"
+echo "PASS: New cert issued ($OLD_SECRET_SERIAL → $NEW_SECRET_SERIAL)"
+
+# ---------------------------------------------------------------------------
+# Step 3: Wait for the new cert to propagate to the pod's volume mount
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 3: Wait for volume propagation ==="
+
+EXPECTED_HASH=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d | sha256sum | awk '{print $1}')
+
+ELAPSED=0; TIMEOUT=180
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  ACTUAL_HASH=$(kubectl exec "deployment/$DEPLOYMENT" -n "$NAMESPACE" -- \
+    cat "$CERT_MOUNT_PATH" 2>/dev/null | sha256sum | awk '{print $1}') || true
+  [ "$EXPECTED_HASH" = "$ACTUAL_HASH" ] && break
+  [ $((ELAPSED % 30)) -eq 0 ] && echo "Waiting for volume sync... (${ELAPSED}s/${TIMEOUT}s)"
+  sleep 5; ELAPSED=$((ELAPSED + 5))
+done
+[ $ELAPSED -lt $TIMEOUT ] || fail "cert volume did not sync within ${TIMEOUT}s"
+echo "PASS: Volume propagation confirmed after ${ELAPSED}s"
+
+# ---------------------------------------------------------------------------
+# Step 4: Verify the server dynamically serves the new cert without restart
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 4: Verify dynamic cert reload (no pod restart) ==="
+
+SERVED_SERIAL=""
+ELAPSED=0; TIMEOUT=180
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  SERVED_SERIAL=$(openssl_serial "$PLUGIN_IP")
+  [ "$SERVED_SERIAL" = "$NEW_SECRET_SERIAL" ] && break
+  [ $((ELAPSED % 30)) -eq 0 ] \
+    && echo "Waiting for reload... (${ELAPSED}s/${TIMEOUT}s) served=${SERVED_SERIAL:-unknown}"
+  sleep 5; ELAPSED=$((ELAPSED + 5))
+done
+
+if [ "$SERVED_SERIAL" != "$NEW_SECRET_SERIAL" ]; then
+  fail "server did not pick up new cert within ${TIMEOUT}s (served=${SERVED_SERIAL:-unknown}, expected=${NEW_SECRET_SERIAL})"
+fi
+echo "PASS: Dynamic cert reload confirmed after ${ELAPSED}s"
+
+# ---------------------------------------------------------------------------
+# Step 5: Verify the pod was NOT restarted
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 5: Verify pod was not restarted ==="
+CURRENT_POD=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
+CURRENT_TS=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || echo "")
+
+if [ "$CURRENT_POD" = "$POD_NAME" ] && [ "$CURRENT_TS" = "$POD_TS" ]; then
+  echo "PASS: Same pod running (name=$POD_NAME, creationTimestamp=$POD_TS)"
+else
+  fail "pod was restarted: before=$POD_NAME/$POD_TS after=$CURRENT_POD/$CURRENT_TS"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: Verify the service endpoint is healthy with the new cert
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 6: Verify /health endpoint after cert rotation ==="
+SVC_URL="https://${DEPLOYMENT}.${NAMESPACE}.svc:${PLUGIN_PORT}/health"
+HTTP_CODE=$(kubectl exec tls-scanner -n "$NAMESPACE" -- \
+  curl -sk -o /dev/null -w '%{http_code}' "$SVC_URL" 2>/dev/null)
+[ "$HTTP_CODE" = "200" ] || fail "/health returned HTTP $HTTP_CODE (expected 200)"
+echo "PASS: /health → HTTP 200"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================="
+echo "PASS: Certificate rotation with dynamic reload verified"
+echo "  Pre-rotation serial:  $OLD_SECRET_SERIAL"
+echo "  Post-rotation serial: $NEW_SECRET_SERIAL"
+echo "  Served serial:        $SERVED_SERIAL"
+echo "  Pod not restarted:    $POD_NAME"
+echo "============================================="

--- a/tests/fixtures/chainsaw-tests/cert-rotation/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/chainsaw-test.yaml
@@ -1,0 +1,99 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cert-rotation
+spec:
+  steps:
+  - name: Detect COO namespace and install tls-scanner
+    try:
+    - command:
+        entrypoint: kubectl
+        args:
+        - get
+        - deployment
+        - -A
+        - -l app.kubernetes.io/name=observability-operator
+        - -o
+        - jsonpath={.items[0].metadata.namespace}
+        outputs:
+        - name: COO_NAMESPACE
+          value: ($stdout)
+    - script:
+        content: |
+          if [ -z "$COO_NAMESPACE" ]; then
+            echo "ERROR: COO_NAMESPACE is empty — observability-operator deployment not found" >&2
+            exit 1
+          fi
+          echo "Detected COO namespace: $COO_NAMESPACE"
+          # Clean up any leftover tls-scanner resources from a previous run
+          kubectl delete pod tls-scanner -n "$COO_NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+          kubectl delete sa tls-scanner -n "$COO_NAMESPACE" 2>/dev/null || true
+          sleep 3
+        env:
+        - name: COO_NAMESPACE
+          value: ($COO_NAMESPACE)
+    - apply:
+        file: 00-install-tls-scanner.yaml
+    - assert:
+        file: 00-assert.yaml
+
+  - name: Scale down observability-operator
+    try:
+    - script:
+        timeout: 2m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}')
+          kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=0
+          kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=60s
+          echo "PASS: observability-operator scaled to 0"
+
+  - name: Verify cert rotation and dynamic reload
+    try:
+    - script:
+        timeout: 10m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}')
+          export NAMESPACE
+          ./01-cert-rotation.sh
+
+  - name: Scale operator back up and cleanup tls-scanner
+    try:
+    - script:
+        timeout: 3m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}')
+          kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=1
+          kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=120s
+          echo "PASS: observability-operator scaled back to 1"
+    - script:
+        timeout: 2m
+        content: |
+          NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+            -o jsonpath='{.items[0].metadata.namespace}')
+          kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+          kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+          kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+          kubectl delete sa tls-scanner -n "$NAMESPACE" 2>/dev/null || true
+          echo "PASS: tls-scanner resources cleaned up"
+
+  catch:
+  - script:
+      timeout: 3m
+      content: |
+        NAMESPACE=$(kubectl get deployment -A -l app.kubernetes.io/name=observability-operator \
+          -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null)
+        NAMESPACE="${NAMESPACE:-openshift-cluster-observability-operator}"
+        kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=1 2>/dev/null || true
+        kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=120s || true
+        kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
+        kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+        kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
+        kubectl delete scc tls-scanner-scc-dt-plugin 2>/dev/null || true
+        kubectl delete sa tls-scanner -n "$NAMESPACE" 2>/dev/null || true


### PR DESCRIPTION
Cherry-pick of #261 to `release-coo-ocp-4.22`.

## Changes
- Wire `GetConfigForClient` so every TLS handshake uses the dynamically reloaded cert instead of the static cert loaded by `ListenAndServeTLS`
- Start the file watcher that detects cert rotation and notifies the controller
- Add cert-rotation chainsaw tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)