### PR TITLE
COO-1826: fix: give env var priority over CLI arg in mergeEnvValue

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -57,14 +57,14 @@ func main() {
 }
 
 func mergeEnvValue(key string, arg string, defaultValue string) string {
-	if arg != "" {
-		return arg
-	}
-
+	// env var takes priority over CLI arg to allow runtime overrides of operator-provided defaults
 	envValue := os.Getenv(key)
-
 	if envValue != "" {
 		return envValue
+	}
+
+	if arg != "" {
+		return arg
 	}
 
 	return defaultValue


### PR DESCRIPTION
## Summary

- `mergeEnvValue` previously checked the CLI argument before the environment variable, causing env vars like `TLS_MIN_VERSION` to be silently ignored when both a CLI arg and an env var were present
- Inverted the priority so env vars always take precedence over CLI args, enabling runtime TLS configuration overrides

## Root Cause

The Cluster Observability Operator passes `-tls-min-version` as a CLI argument derived from the cluster's configured TLS profile (e.g. `-tls-min-version=VersionTLS12` for the Intermediate profile). To enforce a stricter profile such as Modern (TLS 1.3-only), `TLS_MIN_VERSION=VersionTLS13` can be set as a deployment environment variable to override the operator-provided default. The old `mergeEnvValue` implementation returned the CLI arg first, making the env var a no-op — the server kept accepting TLS 1.2 connections even when the env var was set.

The fix ensures env vars take precedence over CLI args so that runtime overrides via environment variables always win, which is the intended design.

## Test plan

- [x] Ran all 6 TLS profile chainsaw tests on-cluster with the fixed image — all pass
  - `tls-profile-setup` — PASS
  - `tls-profile-intermediate` — PASS
  - `tls-profile-modern` — PASS (TLS 1.2 correctly rejected, TLS 1.3 enforced)
  - `tls-profile-custom-ciphers` — PASS
  - `tls-profile-old` — PASS
  - `tls-profile-revert` — PASS
- [x] Existing backend unit tests pass (`make test-unit-backend`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration value resolution: environment variables now take precedence over command-line arguments, with default values used as a final fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->