### PR TITLE
NO-JIRA: test: patch CLI args instead of env vars in TLS profile tests

### DIFF
--- a/tests/fixtures/chainsaw-tests/tls-profile-custom-ciphers/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-custom-ciphers/chainsaw-test.yaml
@@ -10,7 +10,7 @@ spec:
         timeout: 5m
         content: |
           . ../tls-profile/tls-helpers.sh
-          patch_tls_env "VersionTLS12" "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+          patch_tls_args "VersionTLS12" "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
           echo "PASS: Deployment patched with custom cipher suites"
   - name: Verify custom cipher suites
     try:

--- a/tests/fixtures/chainsaw-tests/tls-profile-intermediate/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-intermediate/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
         content: |
           . ../tls-profile/tls-helpers.sh
           detect_fips
-          remove_tls_env
+          remove_tls_args
           verify_nmap_tls_profile "intermediate" "Default Intermediate profile"
           verify_all_endpoints "Default Intermediate profile"
           echo "PASS: Intermediate TLS profile verified (TLS 1.2 + TLS 1.3)"

--- a/tests/fixtures/chainsaw-tests/tls-profile-modern/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-modern/chainsaw-test.yaml
@@ -10,7 +10,7 @@ spec:
         timeout: 5m
         content: |
           . ../tls-profile/tls-helpers.sh
-          patch_tls_env "VersionTLS13" ""
+          patch_tls_args "VersionTLS13" ""
           echo "PASS: Deployment patched with TLS_MIN_VERSION=VersionTLS13"
   - name: Verify Modern TLS profile
     try:

--- a/tests/fixtures/chainsaw-tests/tls-profile-old/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-old/chainsaw-test.yaml
@@ -10,7 +10,7 @@ spec:
         timeout: 5m
         content: |
           . ../tls-profile/tls-helpers.sh
-          patch_tls_env "VersionTLS10" ""
+          patch_tls_args "VersionTLS10" ""
           echo "PASS: Deployment patched with TLS_MIN_VERSION=VersionTLS10"
   - name: Verify Old TLS profile
     try:

--- a/tests/fixtures/chainsaw-tests/tls-profile-revert/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-revert/chainsaw-test.yaml
@@ -46,10 +46,11 @@ spec:
         kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=120s || true
         CURRENT_ARGS=$(kubectl get deployment distributed-tracing -n "$NAMESPACE" \
           -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || echo '[]')
+        CURRENT_ARGS="${CURRENT_ARGS:-[]}"
         NEW_ARGS=$(echo "$CURRENT_ARGS" | jq \
-          '[.[] | select(startswith("-tls-min-version=") or startswith("-tls-cipher-suites=") | not)] + ["-tls-min-version=VersionTLS12"]')
+          '[.[] | select(startswith("-tls-min-version=") or startswith("-tls-cipher-suites=") | not)]')
         kubectl patch deployment distributed-tracing -n "$NAMESPACE" --type=json \
-          -p "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $NEW_ARGS}]" 2>/dev/null || true
+          -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $NEW_ARGS}]" 2>/dev/null || true
         kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
         kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
         kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true

--- a/tests/fixtures/chainsaw-tests/tls-profile-revert/chainsaw-test.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile-revert/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
         content: |
           . ../tls-profile/tls-helpers.sh
           detect_fips
-          remove_tls_env
+          remove_tls_args
           verify_nmap_tls_profile "intermediate" "Reverted Intermediate profile"
           verify_all_endpoints "Reverted Intermediate profile"
           echo "PASS: Reverted to default Intermediate profile"
@@ -44,8 +44,12 @@ spec:
           -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "openshift-cluster-observability-operator")
         kubectl scale deployment observability-operator -n "$NAMESPACE" --replicas=1 2>/dev/null || true
         kubectl rollout status deployment/observability-operator -n "$NAMESPACE" --timeout=120s || true
+        CURRENT_ARGS=$(kubectl get deployment distributed-tracing -n "$NAMESPACE" \
+          -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || echo '[]')
+        NEW_ARGS=$(echo "$CURRENT_ARGS" | jq \
+          '[.[] | select(startswith("-tls-min-version=") or startswith("-tls-cipher-suites=") | not)] + ["-tls-min-version=VersionTLS12"]')
         kubectl patch deployment distributed-tracing -n "$NAMESPACE" --type=json \
-          -p '[{"op": "remove", "path": "/spec/template/spec/containers/0/env"}]' 2>/dev/null || true
+          -p "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $NEW_ARGS}]" 2>/dev/null || true
         kubectl delete pod tls-scanner -n "$NAMESPACE" --force --grace-period=0 2>/dev/null || true
         kubectl delete clusterrolebinding tls-scanner-pods-reader-dt-plugin 2>/dev/null || true
         kubectl delete clusterrole tls-scanner-pods-reader-dt-plugin 2>/dev/null || true

--- a/tests/fixtures/chainsaw-tests/tls-profile/tls-helpers.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/tls-helpers.sh
@@ -14,7 +14,7 @@ LABEL_SELECTOR="app.kubernetes.io/instance=distributed-tracing"
 fail() { echo "FAIL: $1"; exit 1; }
 
 # Scale down the observability-operator to prevent it from reconciling the
-# plugin deployment while we patch TLS env vars for testing.
+# plugin deployment while we patch TLS CLI args for testing.
 scale_down_operator() {
   echo "=== Scaling down $OPERATOR_DEPLOYMENT to prevent reconciliation ==="
   kubectl scale deployment "$OPERATOR_DEPLOYMENT" -n "$NAMESPACE" --replicas=0
@@ -60,34 +60,52 @@ wait_for_rollout() {
   kubectl wait --for=condition=Ready pods -l "$LABEL_SELECTOR" -n "$NAMESPACE" --timeout=120s
 }
 
-# Patch the deployment with TLS environment variables.
-# Args: $1=TLS_MIN_VERSION value (optional), $2=TLS_CIPHER_SUITES value (optional)
-patch_tls_env() {
+# Patch the deployment CLI args with TLS settings, mirroring what COO does when it reads
+# the cluster TLS profile from apiservers.config.openshift.io/cluster.
+# Args: $1=-tls-min-version value (optional), $2=-tls-cipher-suites value (optional, comma-separated)
+patch_tls_args() {
   local min_version="${1:-}"
   local cipher_suites="${2:-}"
 
-  local env_patch='[]'
+  local current_args
+  current_args=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.containers[0].args}')
+
+  local new_args="$current_args"
 
   if [ -n "$min_version" ]; then
-    env_patch=$(echo "$env_patch" | jq --arg v "$min_version" '. + [{"name": "TLS_MIN_VERSION", "value": $v}]')
+    new_args=$(echo "$new_args" | jq --arg v "-tls-min-version=$min_version" \
+      '[.[] | select(startswith("-tls-min-version=") | not)] + [$v]')
   fi
 
   if [ -n "$cipher_suites" ]; then
-    env_patch=$(echo "$env_patch" | jq --arg v "$cipher_suites" '. + [{"name": "TLS_CIPHER_SUITES", "value": $v}]')
+    new_args=$(echo "$new_args" | jq --arg v "-tls-cipher-suites=$cipher_suites" \
+      '[.[] | select(startswith("-tls-cipher-suites=") | not)] + [$v]')
+  else
+    new_args=$(echo "$new_args" | jq \
+      '[.[] | select(startswith("-tls-cipher-suites=") | not)]')
   fi
 
-  echo "Patching deployment with env: $env_patch"
+  echo "Patching deployment args: $new_args"
   kubectl patch deployment "$DEPLOYMENT" -n "$NAMESPACE" --type=json \
-    -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env\", \"value\": $env_patch}]"
+    -p "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $new_args}]"
 
   wait_for_rollout
 }
 
-# Remove all TLS environment variables from the deployment (revert to default).
-remove_tls_env() {
-  echo "Removing TLS environment variables from deployment..."
+# Revert TLS CLI args to the COO default (Intermediate profile: -tls-min-version=VersionTLS12).
+remove_tls_args() {
+  echo "Reverting TLS CLI args to COO Intermediate defaults..."
+  local current_args
+  current_args=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.containers[0].args}')
+
+  local new_args
+  new_args=$(echo "$current_args" | jq \
+    '[.[] | select(startswith("-tls-min-version=") or startswith("-tls-cipher-suites=") | not)] + ["-tls-min-version=VersionTLS12"]')
+
   kubectl patch deployment "$DEPLOYMENT" -n "$NAMESPACE" --type=json \
-    -p '[{"op": "remove", "path": "/spec/template/spec/containers/0/env"}]' 2>/dev/null || true
+    -p "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $new_args}]"
 
   wait_for_rollout
 }

--- a/tests/fixtures/chainsaw-tests/tls-profile/tls-helpers.sh
+++ b/tests/fixtures/chainsaw-tests/tls-profile/tls-helpers.sh
@@ -70,6 +70,8 @@ patch_tls_args() {
   local current_args
   current_args=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
     -o jsonpath='{.spec.template.spec.containers[0].args}')
+  # Default to empty array when COO does not set any args
+  current_args="${current_args:-[]}"
 
   local new_args="$current_args"
 
@@ -87,25 +89,29 @@ patch_tls_args() {
   fi
 
   echo "Patching deployment args: $new_args"
+  # Use "add" so the patch works whether or not the args field already exists.
   kubectl patch deployment "$DEPLOYMENT" -n "$NAMESPACE" --type=json \
-    -p "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $new_args}]"
+    -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $new_args}]"
 
   wait_for_rollout
 }
 
-# Revert TLS CLI args to the COO default (Intermediate profile: -tls-min-version=VersionTLS12).
+# Remove TLS CLI args added for testing. The plugin defaults to the Intermediate profile
+# (TLS 1.2+) when no -tls-min-version arg is present, so we strip rather than restore a
+# specific value — this works regardless of whether COO passes the arg in CI or not.
 remove_tls_args() {
-  echo "Reverting TLS CLI args to COO Intermediate defaults..."
+  echo "Removing test TLS CLI args from deployment..."
   local current_args
   current_args=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
     -o jsonpath='{.spec.template.spec.containers[0].args}')
+  current_args="${current_args:-[]}"
 
   local new_args
   new_args=$(echo "$current_args" | jq \
-    '[.[] | select(startswith("-tls-min-version=") or startswith("-tls-cipher-suites=") | not)] + ["-tls-min-version=VersionTLS12"]')
+    '[.[] | select(startswith("-tls-min-version=") or startswith("-tls-cipher-suites=") | not)]')
 
   kubectl patch deployment "$DEPLOYMENT" -n "$NAMESPACE" --type=json \
-    -p "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $new_args}]"
+    -p "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": $new_args}]"
 
   wait_for_rollout
 }


### PR DESCRIPTION
## Summary

- TLS profile chainsaw tests were previously patching deployment env vars (`TLS_MIN_VERSION`, `TLS_CIPHER_SUITES`) to simulate different TLS profiles
- COO reads the cluster TLS profile from `apiservers.config.openshift.io/cluster` and passes it to the plugin as **CLI args** (e.g. `-tls-min-version=VersionTLS12`), not env vars
- CLI args take priority over env vars in `mergeEnvValue`, so patching env vars had no effect — the tests were not accurately simulating what COO does
- Replace `patch_tls_env`/`remove_tls_env` with `patch_tls_args`/`remove_tls_args` to directly patch deployment CLI args, matching COO's actual behavior

## Changes

- `tls-helpers.sh`:
  - `patch_tls_args`: gets current args array (defaulting to `[]` when COO sets none), replaces TLS-specific args in-place, patches with `"op": "add"` (works whether or not the `args` field exists)
  - `remove_tls_args`: strips `-tls-min-version` and `-tls-cipher-suites` args without hardcoding a restore value — the plugin defaults to Intermediate (TLS 1.2+) when the arg is absent, which is correct for both COO environments that pass the arg and CI environments that do not
- `tls-profile-intermediate`, `tls-profile-modern`, `tls-profile-custom-ciphers`, `tls-profile-old`, `tls-profile-revert`: update callsites to use the new functions
- `tls-profile-revert` catch block: apply the same safe strip-and-restore logic

## Test plan

- [x] Run all 6 TLS profile chainsaw tests in sequence on an OCP cluster with COO and the plugin installed