### PR TITLE
TRACING-6170: Update Perses dependencies to 0.54.0-beta.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,14 +17,14 @@
         "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-templates": "^6.4.1",
-        "@perses-dev/components": "^0.53.0",
+        "@perses-dev/components": "0.54.0-beta.1",
         "@perses-dev/core": "0.53.0",
-        "@perses-dev/dashboards": "^0.53.0",
-        "@perses-dev/plugin-system": "^0.53.0",
-        "@perses-dev/scatter-chart-plugin": "^0.10.0",
-        "@perses-dev/tempo-plugin": "^0.57.0",
-        "@perses-dev/trace-table-plugin": "^0.10.0",
-        "@perses-dev/tracing-gantt-chart-plugin": "^0.12.0",
+        "@perses-dev/dashboards": "0.54.0-beta.1",
+        "@perses-dev/plugin-system": "0.54.0-beta.1",
+        "@perses-dev/scatter-chart-plugin": "0.11.0-beta.0",
+        "@perses-dev/tempo-plugin": "0.58.0-beta.0",
+        "@perses-dev/trace-table-plugin": "0.11.0-beta.0",
+        "@perses-dev/tracing-gantt-chart-plugin": "0.13.0-beta.0",
         "copy-webpack-plugin": "^14.0.0",
         "i18next": "^25.10.5",
         "i18next-http-backend": "^3.0.2",
@@ -3114,11 +3114,14 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fontsource/lato": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-4.5.10.tgz",
-      "integrity": "sha512-2hYR6r661Cq9B8zugtu6yxuOKqrVhAgfOSaPSq8XoxbC4ebsl0KOTy/vPoP+9U7JuQVLfrmikirW4a9Z0nDUug==",
-      "license": "MIT"
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@grafana/lezer-traceql": {
       "version": "0.0.25",
@@ -4517,21 +4520,29 @@
       "license": "MIT"
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.21.6.tgz",
-      "integrity": "sha512-lJMmdhD4VKVkeg8RHb+Jwe6Ou9zKVgjtb1inEURDG/sSS2ksdZA8pVKLYbRPRbdmjr193Y8gJfqFbI2dqoyc/g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.5.0.tgz",
+      "integrity": "sha512-Ux9XVW//K6K+KHKPdc0Jnc7RtTpZaEXgbVhp5yovtFkCJVt8hEClcTeuI18MvvLiV/q2hUpCU5Wsf9zNaIYStQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.21.6",
+        "@module-federation/sdk": "2.5.0",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/@module-federation/sdk": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
-      "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
-      "license": "MIT"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/semver": {
       "version": "7.6.3",
@@ -4546,14 +4557,13 @@
       }
     },
     "node_modules/@module-federation/cli": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-0.21.6.tgz",
-      "integrity": "sha512-qNojnlc8pTyKtK7ww3i/ujLrgWwgXqnD5DcDPsjADVIpu7STaoaVQ0G5GJ7WWS/ajXw6EyIAAGW/AMFh4XUxsQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.5.0.tgz",
+      "integrity": "sha512-+czXA6yoiiF9W6+YEOCpQE6zpGZpA89X0oCEz3EaWPTkL4chEbxurjpME8CMnJk9iuFxl167+cBQiQlVBiHGGg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "0.21.6",
-        "@module-federation/sdk": "0.21.6",
-        "chalk": "3.0.0",
+        "@module-federation/dts-plugin": "2.5.0",
+        "@module-federation/sdk": "2.5.0",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
@@ -4565,56 +4575,18 @@
       }
     },
     "node_modules/@module-federation/cli/node_modules/@module-federation/sdk": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
-      "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/cli/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
       },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@module-federation/cli/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@module-federation/cli/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@module-federation/cli/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
     },
     "node_modules/@module-federation/cli/node_modules/commander": {
       "version": "11.1.0",
@@ -4625,96 +4597,21 @@
         "node": ">=16"
       }
     },
-    "node_modules/@module-federation/cli/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@module-federation/cli/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@module-federation/data-prefetch": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.21.6.tgz",
-      "integrity": "sha512-8HD7ZhtWZ9vl6i3wA7M8cEeCRdtvxt09SbMTfqIPm+5eb/V4ijb8zGTYSRhNDb5RCB+BAixaPiZOWKXJ63/rVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.21.6",
-        "@module-federation/sdk": "0.21.6",
-        "fs-extra": "9.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/error-codes": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.21.6.tgz",
-      "integrity": "sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/runtime": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.21.6.tgz",
-      "integrity": "sha512-+caXwaQqwTNh+CQqyb4mZmXq7iEemRDrTZQGD+zyeH454JAYnJ3s/3oDFizdH6245pk+NiqDyOOkHzzFQorKhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.21.6",
-        "@module-federation/runtime-core": "0.21.6",
-        "@module-federation/sdk": "0.21.6"
-      }
-    },
-    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/runtime-core": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.21.6.tgz",
-      "integrity": "sha512-5Hd1Y5qp5lU/aTiK66lidMlM/4ji2gr3EXAtJdreJzkY+bKcI5+21GRcliZ4RAkICmvdxQU5PHPL71XmNc7Lsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.21.6",
-        "@module-federation/sdk": "0.21.6"
-      }
-    },
-    "node_modules/@module-federation/data-prefetch/node_modules/@module-federation/sdk": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
-      "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
-      "license": "MIT"
-    },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.21.6.tgz",
-      "integrity": "sha512-YIsDk8/7QZIWn0I1TAYULniMsbyi2LgKTi9OInzVmZkwMC6644x/ratTWBOUDbdY1Co+feNkoYeot1qIWv2L7w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.5.0.tgz",
+      "integrity": "sha512-q7KDhJ5tn2HrUV7uMuh/L3TaaztUosE+4LAb90sxx0pPPqWRwlpBpxu1REubv5BWXmU1K/Ozn14u6jRbjLVaGA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.21.6",
-        "@module-federation/managers": "0.21.6",
-        "@module-federation/sdk": "0.21.6",
-        "@module-federation/third-party-dts-extractor": "0.21.6",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "^1.12.0",
-        "chalk": "3.0.0",
-        "fs-extra": "9.1.0",
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/managers": "2.5.0",
+        "@module-federation/sdk": "2.5.0",
+        "@module-federation/third-party-dts-extractor": "2.5.0",
+        "adm-zip": "0.5.10",
+        "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
-        "koa": "3.0.3",
-        "lodash.clonedeepwith": "4.5.0",
-        "log4js": "6.9.1",
         "node-schedule": "2.1.1",
-        "rambda": "^9.1.0",
+        "undici": "7.24.7",
         "ws": "8.18.0"
       },
       "peerDependencies": {
@@ -4728,82 +4625,32 @@
       }
     },
     "node_modules/@module-federation/dts-plugin/node_modules/@module-federation/error-codes": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.21.6.tgz",
-      "integrity": "sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.0.tgz",
+      "integrity": "sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==",
       "license": "MIT"
     },
     "node_modules/@module-federation/dts-plugin/node_modules/@module-federation/sdk": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
-      "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/dts-plugin/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
       },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@module-federation/dts-plugin/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@module-federation/dts-plugin/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@module-federation/dts-plugin/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/dts-plugin/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+    "node_modules/@module-federation/dts-plugin/node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@module-federation/dts-plugin/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@module-federation/dts-plugin/node_modules/ws": {
@@ -4828,24 +4675,24 @@
       }
     },
     "node_modules/@module-federation/enhanced": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.21.6.tgz",
-      "integrity": "sha512-8PFQxtmXc6ukBC4CqGIoc96M2Ly9WVwCPu4Ffvt+K/SB6rGbeFeZoYAwREV1zGNMJ5v5ly6+AHIEOBxNuSnzSg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.5.0.tgz",
+      "integrity": "sha512-P91tzwyKSCQ6AwirqvAvTqWqmTY79ndpH0uenejFw+bbLpWrjuY0q+iZUXCV/7CSNmqwH2bkA/ssuyZljmcMVQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.21.6",
-        "@module-federation/cli": "0.21.6",
-        "@module-federation/data-prefetch": "0.21.6",
-        "@module-federation/dts-plugin": "0.21.6",
-        "@module-federation/error-codes": "0.21.6",
-        "@module-federation/inject-external-runtime-core-plugin": "0.21.6",
-        "@module-federation/managers": "0.21.6",
-        "@module-federation/manifest": "0.21.6",
-        "@module-federation/rspack": "0.21.6",
-        "@module-federation/runtime-tools": "0.21.6",
-        "@module-federation/sdk": "0.21.6",
-        "btoa": "^1.2.1",
-        "schema-utils": "^4.3.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.5.0",
+        "@module-federation/cli": "2.5.0",
+        "@module-federation/dts-plugin": "2.5.0",
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.5.0",
+        "@module-federation/managers": "2.5.0",
+        "@module-federation/manifest": "2.5.0",
+        "@module-federation/rspack": "2.5.0",
+        "@module-federation/runtime-tools": "2.5.0",
+        "@module-federation/sdk": "2.5.0",
+        "@module-federation/webpack-bundler-runtime": "2.5.0",
+        "schema-utils": "4.3.0",
+        "tapable": "2.3.0",
         "upath": "2.0.1"
       },
       "bin": {
@@ -4869,65 +4716,127 @@
       }
     },
     "node_modules/@module-federation/enhanced/node_modules/@module-federation/error-codes": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.21.6.tgz",
-      "integrity": "sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.0.tgz",
+      "integrity": "sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==",
       "license": "MIT"
     },
     "node_modules/@module-federation/enhanced/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.21.6.tgz",
-      "integrity": "sha512-DJQne7NQ988AVi3QB8byn12FkNb+C2lBeU1NRf8/WbL0gmHsr6kW8hiEJCm8LYaURwtsQqtsEV7i+8+51qjSmQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.5.0.tgz",
+      "integrity": "sha512-e2KyTHpesBrPXGHMh4d4+s2xBiNoxbiFJkPRYHMCl81a/Gu+byrMkriZcV4VM/TFvBIlrgOJisVc1nnBI5UDRQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "0.21.6"
+        "@module-federation/runtime-tools": "2.5.0"
       }
     },
     "node_modules/@module-federation/enhanced/node_modules/@module-federation/runtime": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.21.6.tgz",
-      "integrity": "sha512-+caXwaQqwTNh+CQqyb4mZmXq7iEemRDrTZQGD+zyeH454JAYnJ3s/3oDFizdH6245pk+NiqDyOOkHzzFQorKhQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.5.0.tgz",
+      "integrity": "sha512-dOc7pFEf8aruHBk5hoJLnvwkCa5ELT78q3o9dqcdaa/TT74X5z0FT0BsaGaRBPcse/iP6czK3fWd7RLv5ZKP5g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.21.6",
-        "@module-federation/runtime-core": "0.21.6",
-        "@module-federation/sdk": "0.21.6"
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/runtime-core": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
       }
     },
     "node_modules/@module-federation/enhanced/node_modules/@module-federation/runtime-core": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.21.6.tgz",
-      "integrity": "sha512-5Hd1Y5qp5lU/aTiK66lidMlM/4ji2gr3EXAtJdreJzkY+bKcI5+21GRcliZ4RAkICmvdxQU5PHPL71XmNc7Lsw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.5.0.tgz",
+      "integrity": "sha512-STmhQ3c6/hunba2FMP6GrHazXU/8GuN7Gk4dOkWNRpnqYIoD8Wx4MNl76j3HdCzBESC7uSMXTniksVaM1+xxyA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.21.6",
-        "@module-federation/sdk": "0.21.6"
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
       }
     },
     "node_modules/@module-federation/enhanced/node_modules/@module-federation/runtime-tools": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.21.6.tgz",
-      "integrity": "sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.5.0.tgz",
+      "integrity": "sha512-fR3Na6V78ov3/O17Mev+1vydfmqlYWP4ZNxD/bBkmqKhCO7jMdthNTT02yDljlCyhYl6+X90UJlFhwFle6rIsw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.21.6",
-        "@module-federation/webpack-bundler-runtime": "0.21.6"
+        "@module-federation/runtime": "2.5.0",
+        "@module-federation/webpack-bundler-runtime": "2.5.0"
       }
     },
     "node_modules/@module-federation/enhanced/node_modules/@module-federation/sdk": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
-      "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
-      "license": "MIT"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@module-federation/enhanced/node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.21.6.tgz",
-      "integrity": "sha512-7zIp3LrcWbhGuFDTUMLJ2FJvcwjlddqhWGxi/MW3ur1a+HaO8v5tF2nl+vElKmbG1DFLU/52l3PElVcWf/YcsQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.5.0.tgz",
+      "integrity": "sha512-UxVad+tNZYkBnZzqJQsZa0pB5gO5cJoCjMumOo3bhzXBJVqHsFupfeHa8Nk7WrRVbJE6zRT9ZHK0s0NDWBMyJw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.21.6",
-        "@module-federation/sdk": "0.21.6"
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/runtime": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/enhanced/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@module-federation/error-codes": {
@@ -4938,125 +4847,71 @@
       "peer": true
     },
     "node_modules/@module-federation/managers": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.21.6.tgz",
-      "integrity": "sha512-BeV6m2/7kF5MDVz9JJI5T8h8lMosnXkH2bOxxFewcra7ZjvDOgQu7WIio0mgk5l1zjNPvnEVKhnhrenEdcCiWg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.5.0.tgz",
+      "integrity": "sha512-9b5mU/7OYbKrYUJmhZ1kkfeJCZqR7qX6/FWp+oOfZMzUynN7Rb41dwoUs3TdnOKzbZ3CCwtZ2WsR4pF9ZNvuJA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.21.6",
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0"
+        "@module-federation/sdk": "2.5.0",
+        "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/managers/node_modules/@module-federation/sdk": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
-      "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
-      "license": "MIT"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@module-federation/manifest": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.21.6.tgz",
-      "integrity": "sha512-yg93+I1qjRs5B5hOSvjbjmIoI2z3th8/yst9sfwvx4UDOG1acsE3HHMyPN0GdoIGwplC/KAnU5NmUz4tREUTGQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.5.0.tgz",
+      "integrity": "sha512-pmwQCGWjM2oKY7CkR7nEDOfMK0bNFJUifuDxuOB5iOWhU+Rp92UyyBI9IbJAtiISTSFGtuKRy40peJGvQq2VcQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "0.21.6",
-        "@module-federation/managers": "0.21.6",
-        "@module-federation/sdk": "0.21.6",
-        "chalk": "3.0.0",
+        "@module-federation/dts-plugin": "2.5.0",
+        "@module-federation/managers": "2.5.0",
+        "@module-federation/sdk": "2.5.0",
         "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/manifest/node_modules/@module-federation/sdk": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
-      "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/manifest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
       },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@module-federation/manifest/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@module-federation/manifest/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@module-federation/manifest/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/manifest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@module-federation/manifest/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
       }
     },
     "node_modules/@module-federation/rspack": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.21.6.tgz",
-      "integrity": "sha512-SB+z1P+Bqe3R6geZje9dp0xpspX6uash+zO77nodmUy8PTTBlkL7800Cq2FMLKUdoTZHJTBVXf0K6CqQWSlItg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.5.0.tgz",
+      "integrity": "sha512-OAFMpMXuLEQFmWBuC1I7LNDQ8N3CDANXe0YGPWkIPNxKq5Tj/KNfDidmutoYgvXlZKOM4yKBKBsL6Xt/UvtOIw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.21.6",
-        "@module-federation/dts-plugin": "0.21.6",
-        "@module-federation/inject-external-runtime-core-plugin": "0.21.6",
-        "@module-federation/managers": "0.21.6",
-        "@module-federation/manifest": "0.21.6",
-        "@module-federation/runtime-tools": "0.21.6",
-        "@module-federation/sdk": "0.21.6",
-        "btoa": "1.2.1"
+        "@module-federation/bridge-react-webpack-plugin": "2.5.0",
+        "@module-federation/dts-plugin": "2.5.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.5.0",
+        "@module-federation/managers": "2.5.0",
+        "@module-federation/manifest": "2.5.0",
+        "@module-federation/runtime-tools": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
       },
       "peerDependencies": {
-        "@rspack/core": ">=0.7",
+        "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
         "typescript": "^4.9.0 || ^5.0.0",
         "vue-tsc": ">=1.0.24"
       },
@@ -5070,65 +4925,74 @@
       }
     },
     "node_modules/@module-federation/rspack/node_modules/@module-federation/error-codes": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.21.6.tgz",
-      "integrity": "sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.0.tgz",
+      "integrity": "sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==",
       "license": "MIT"
     },
     "node_modules/@module-federation/rspack/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.21.6.tgz",
-      "integrity": "sha512-DJQne7NQ988AVi3QB8byn12FkNb+C2lBeU1NRf8/WbL0gmHsr6kW8hiEJCm8LYaURwtsQqtsEV7i+8+51qjSmQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.5.0.tgz",
+      "integrity": "sha512-e2KyTHpesBrPXGHMh4d4+s2xBiNoxbiFJkPRYHMCl81a/Gu+byrMkriZcV4VM/TFvBIlrgOJisVc1nnBI5UDRQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "0.21.6"
+        "@module-federation/runtime-tools": "2.5.0"
       }
     },
     "node_modules/@module-federation/rspack/node_modules/@module-federation/runtime": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.21.6.tgz",
-      "integrity": "sha512-+caXwaQqwTNh+CQqyb4mZmXq7iEemRDrTZQGD+zyeH454JAYnJ3s/3oDFizdH6245pk+NiqDyOOkHzzFQorKhQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.5.0.tgz",
+      "integrity": "sha512-dOc7pFEf8aruHBk5hoJLnvwkCa5ELT78q3o9dqcdaa/TT74X5z0FT0BsaGaRBPcse/iP6czK3fWd7RLv5ZKP5g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.21.6",
-        "@module-federation/runtime-core": "0.21.6",
-        "@module-federation/sdk": "0.21.6"
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/runtime-core": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
       }
     },
     "node_modules/@module-federation/rspack/node_modules/@module-federation/runtime-core": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.21.6.tgz",
-      "integrity": "sha512-5Hd1Y5qp5lU/aTiK66lidMlM/4ji2gr3EXAtJdreJzkY+bKcI5+21GRcliZ4RAkICmvdxQU5PHPL71XmNc7Lsw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.5.0.tgz",
+      "integrity": "sha512-STmhQ3c6/hunba2FMP6GrHazXU/8GuN7Gk4dOkWNRpnqYIoD8Wx4MNl76j3HdCzBESC7uSMXTniksVaM1+xxyA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.21.6",
-        "@module-federation/sdk": "0.21.6"
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
       }
     },
     "node_modules/@module-federation/rspack/node_modules/@module-federation/runtime-tools": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.21.6.tgz",
-      "integrity": "sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.5.0.tgz",
+      "integrity": "sha512-fR3Na6V78ov3/O17Mev+1vydfmqlYWP4ZNxD/bBkmqKhCO7jMdthNTT02yDljlCyhYl6+X90UJlFhwFle6rIsw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.21.6",
-        "@module-federation/webpack-bundler-runtime": "0.21.6"
+        "@module-federation/runtime": "2.5.0",
+        "@module-federation/webpack-bundler-runtime": "2.5.0"
       }
     },
     "node_modules/@module-federation/rspack/node_modules/@module-federation/sdk": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.6.tgz",
-      "integrity": "sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==",
-      "license": "MIT"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@module-federation/rspack/node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.21.6.tgz",
-      "integrity": "sha512-7zIp3LrcWbhGuFDTUMLJ2FJvcwjlddqhWGxi/MW3ur1a+HaO8v5tF2nl+vElKmbG1DFLU/52l3PElVcWf/YcsQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.5.0.tgz",
+      "integrity": "sha512-UxVad+tNZYkBnZzqJQsZa0pB5gO5cJoCjMumOo3bhzXBJVqHsFupfeHa8Nk7WrRVbJE6zRT9ZHK0s0NDWBMyJw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.21.6",
-        "@module-federation/sdk": "0.21.6"
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/runtime": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
       }
     },
     "node_modules/@module-federation/runtime": {
@@ -5173,13 +5037,12 @@
       "peer": true
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.21.6.tgz",
-      "integrity": "sha512-Il6x4hLsvCgZNk1DFwuMBNeoxD1BsZ5AW2BI/nUgu0k5FiAvfcz1OFawRFEHtaM/kVrCsymMOW7pCao90DaX3A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.5.0.tgz",
+      "integrity": "sha512-5di43LGk2ies86Cj8QyzYr540Ijc+nyPqYziyFotL6Pparnu+uf3b3ERfEyQfBmEcyGk1MpitQIO2J3bd9BcNw==",
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0",
         "resolve": "1.22.8"
       }
     },
@@ -6080,18 +5943,20 @@
       }
     },
     "node_modules/@perses-dev/components": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.53.1.tgz",
-      "integrity": "sha512-29zgT5oc6mf8E2FSWr/38nphtbdGc27oNM9IPmuE0pYmhKohnZxBehGGFHWTr3px8mv3VRrmh922+F1hWEa4yg==",
+      "version": "0.54.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/components/-/components-0.54.0-beta.1.tgz",
+      "integrity": "sha512-xssaITVuj6ay/4FaT3HsTeIPwqKZ9P81TejAJbiXr0tH4eSh9p2BAYp7LkbHgAtLecLr3TsLo4C4iGc3iJhnqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
         "@codemirror/lang-json": "^6.0.1",
         "@date-fns/tz": "^1.4.1",
-        "@fontsource/lato": "^4.5.10",
+        "@fontsource/inter": "^5.0.0",
         "@mui/x-date-pickers": "^7.23.1",
         "@perses-dev/core": "0.53.0",
+        "@perses-dev/spec": "0.2.0-beta.0",
+        "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-table": "^8.20.5",
         "@uiw/react-codemirror": "^4.19.1",
         "date-fns": "^4.1.0",
@@ -6107,6 +5972,8 @@
         "react-virtuoso": "^4.12.2"
       },
       "peerDependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
         "@mui/material": "^6.1.10",
         "lodash": "^4.17.21",
         "react": "^17.0.2 || ^18.0.0",
@@ -6127,14 +5994,16 @@
       }
     },
     "node_modules/@perses-dev/dashboards": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.53.1.tgz",
-      "integrity": "sha512-JxbqWuSubJb8qm98Vb+dQHFPbZwg9Gh0mCBCJrcIzlz4u2tevPE+Jtmzig6+fPKscjQJ0tqL7GGc38bJlzrA7A==",
+      "version": "0.54.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/dashboards/-/dashboards-0.54.0-beta.1.tgz",
+      "integrity": "sha512-PizFiH50yj+iQtKr8wJb7KRKElXwlgKQPP/Q85Z/GNHGCVj/iVM1+K4us7jzgs0+M4oD4SH7KdwwhunrmT+1Og==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@perses-dev/components": "0.53.1",
+        "@perses-dev/components": "0.54.0-beta.1",
         "@perses-dev/core": "0.53.0",
-        "@perses-dev/plugin-system": "0.53.1",
+        "@perses-dev/plugin-system": "0.54.0-beta.1",
+        "@perses-dev/spec": "0.2.0-beta.0",
+        "@tanstack/react-hotkeys": "^0.9.1",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^4.1.0",
         "immer": "^10.1.1",
@@ -6156,17 +6025,17 @@
       }
     },
     "node_modules/@perses-dev/explore": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.53.1.tgz",
-      "integrity": "sha512-xdWdbhNvWalmiDkjWEfRlJ/DgVYyTZoRWcuMhqtAYzKJ5/6CDK6d/l/HIx7jk+IkfvXUia0BJQ3kGRTWTgwSsg==",
+      "version": "0.54.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/explore/-/explore-0.54.0-beta.1.tgz",
+      "integrity": "sha512-aPHAbTzrIgIv9w1LUOmzi7DZRB/aXiZQNaml7FeQztCViqekpTKDnfe8fA9xI+PGhZz0j/3f1SAS9Uxkos4gTA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@nexucis/fuzzy": "^0.5.1",
-        "@perses-dev/components": "0.53.1",
+        "@perses-dev/components": "0.54.0-beta.1",
         "@perses-dev/core": "0.53.0",
-        "@perses-dev/dashboards": "0.53.1",
-        "@perses-dev/plugin-system": "0.53.1",
+        "@perses-dev/dashboards": "0.54.0-beta.1",
+        "@perses-dev/plugin-system": "0.54.0-beta.1",
         "@types/react-grid-layout": "^1.3.2",
         "date-fns": "^4.1.0",
         "immer": "^10.1.1",
@@ -6179,7 +6048,7 @@
         "use-immer": "^0.11.0",
         "use-query-params": "^2.2.1",
         "use-resize-observer": "^9.0.0",
-        "zod": "^3.21.4",
+        "zod": "^3.25.76",
         "zustand": "^4.3.3"
       },
       "peerDependencies": {
@@ -6190,23 +6059,26 @@
       }
     },
     "node_modules/@perses-dev/plugin-system": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.53.1.tgz",
-      "integrity": "sha512-woR+k+aJsWHSAfQFEov+unBt9Loqr8J5pNDAQ66EJD3H1UXVd30OqGNaMoJ9fNzZGLVzHn6rxfj1XNnX7DgUkw==",
+      "version": "0.54.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@perses-dev/plugin-system/-/plugin-system-0.54.0-beta.1.tgz",
+      "integrity": "sha512-7l2yjvlyWn0a4LsxntefqoRM9VlZRx4qfH/uN7XNIbI3ycsMnjSlSvshknXcUr3/ukwMPv2jbah3Z1M9hYEEBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@module-federation/enhanced": "^0.21.4",
-        "@perses-dev/components": "0.53.1",
+        "@module-federation/enhanced": "^2.3.3",
+        "@perses-dev/components": "0.54.0-beta.1",
         "@perses-dev/core": "0.53.0",
+        "@perses-dev/spec": "0.2.0-beta.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "immer": "^10.1.1",
         "react-hook-form": "^7.46.1",
         "use-immer": "^0.11.0",
         "use-query-params": "^2.2.1",
-        "zod": "^3.22.2"
+        "zod": "^3.25.76"
       },
       "peerDependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
         "@hookform/resolvers": "^3.2.0",
         "@mui/material": "^6.1.10",
         "@tanstack/react-query": "^4.39.1",
@@ -6215,9 +6087,9 @@
       }
     },
     "node_modules/@perses-dev/scatter-chart-plugin": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/scatter-chart-plugin/-/scatter-chart-plugin-0.10.0.tgz",
-      "integrity": "sha512-NMMBR4K7z4crXhUxanV29Np2hc3W7nVV9ZOkWs3f0seFb4xj8F72SGLBQl/Fi9DaYPCGHIL8xaBXGXrOyBx3LA==",
+      "version": "0.11.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/scatter-chart-plugin/-/scatter-chart-plugin-0.11.0-beta.0.tgz",
+      "integrity": "sha512-o2iaqT4mZWGllnbUD+bI2375td7Qcdsa1tuqY+twhjjSCKmBHEFVK8XdLEC0ZXfJPiBX78BuFtMQ8VESq2IjNw==",
       "dependencies": {
         "react-virtuoso": "^4.12.2"
       },
@@ -6225,9 +6097,9 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.53.0",
-        "@perses-dev/core": "^0.53.0-rc.2",
-        "@perses-dev/plugin-system": "^0.53.0",
+        "@perses-dev/components": "^0.54.0-beta.1",
+        "@perses-dev/core": "^0.53.0",
+        "@perses-dev/plugin-system": "^0.54.0-beta.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -6237,10 +6109,66 @@
         "use-resize-observer": "^9.0.0"
       }
     },
+    "node_modules/@perses-dev/spec": {
+      "version": "0.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/spec/-/spec-0.2.0-beta.0.tgz",
+      "integrity": "sha512-9qT3ofOjBcO7okudC9Rz8t8ugNcTscYincvvmyFtZ/9oHrkDTiJPcRHLZYoCPE6r70OEj27JpvCqWCCil5yA1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "mathjs": "^15.1.1",
+        "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@perses-dev/spec/node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/@perses-dev/spec/node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@perses-dev/spec/node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@perses-dev/tempo-plugin": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/tempo-plugin/-/tempo-plugin-0.57.0.tgz",
-      "integrity": "sha512-qlIWsvTXSlgGr+FFfiG/uF1d22MeGOWiFgDso4e4DFuMSXUBKA9UCjnK+T9sXwWbi1z2hdXCDxImI0OTZ7RGdg==",
+      "version": "0.58.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/tempo-plugin/-/tempo-plugin-0.58.0-beta.0.tgz",
+      "integrity": "sha512-yTa1cXV6XsSfkQvDCs4fq2EBzcLCPrjeRpa6tSH4ONFntXcbgylLnxWBsEB1SW+vS97DxrK8UyUn68rIuW5Tkw==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.0",
         "@grafana/lezer-traceql": "^0.0.25",
@@ -6250,11 +6178,11 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.53.0",
-        "@perses-dev/core": "^0.53.0-rc.2",
-        "@perses-dev/dashboards": "^0.53.0",
-        "@perses-dev/explore": "^0.53.0",
-        "@perses-dev/plugin-system": "^0.53.0",
+        "@perses-dev/components": "^0.54.0-beta.1",
+        "@perses-dev/core": "^0.53.0",
+        "@perses-dev/dashboards": "^0.54.0-beta.1",
+        "@perses-dev/explore": "^0.54.0-beta.1",
+        "@perses-dev/plugin-system": "^0.54.0-beta.1",
         "@tanstack/react-query": "^4.39.1",
         "@uiw/react-codemirror": "^4.25.3",
         "date-fns": "^4.1.0",
@@ -6269,9 +6197,9 @@
       }
     },
     "node_modules/@perses-dev/trace-table-plugin": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/trace-table-plugin/-/trace-table-plugin-0.10.0.tgz",
-      "integrity": "sha512-2JixrY/cjZcQ+BKJEB2or0Iwv/74jSY2GEfRecjnCdOwwBRtLo57nU9QsINQfSxQ29SLhPqfkfsYi4n/HgJAIw==",
+      "version": "0.11.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/trace-table-plugin/-/trace-table-plugin-0.11.0-beta.0.tgz",
+      "integrity": "sha512-dVEAQWBrfpsF/fM/N9S9ClSxdHqgQf/t7ki/4hu944mSaEIYQl3QnRZck5plcngYrssqgCr7lTjbsK/E5EeF7Q==",
       "dependencies": {
         "@mui/x-data-grid": "^7.20.0"
       },
@@ -6279,9 +6207,9 @@
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.53.0",
-        "@perses-dev/core": "^0.53.0-rc.2",
-        "@perses-dev/plugin-system": "^0.53.0",
+        "@perses-dev/components": "^0.54.0-beta.1",
+        "@perses-dev/core": "^0.53.0",
+        "@perses-dev/plugin-system": "^0.54.0-beta.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -6292,19 +6220,20 @@
       }
     },
     "node_modules/@perses-dev/tracing-gantt-chart-plugin": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@perses-dev/tracing-gantt-chart-plugin/-/tracing-gantt-chart-plugin-0.12.0.tgz",
-      "integrity": "sha512-0FTO2vtgaFUxjHiLtiXBgWrljptazi4uiz4Ib6w10gygvKP+fIVQLaUpP5H1DsQWJctAQXN4wlhl5Jjhfnngug==",
+      "version": "0.13.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@perses-dev/tracing-gantt-chart-plugin/-/tracing-gantt-chart-plugin-0.13.0-beta.0.tgz",
+      "integrity": "sha512-fGr/YfVkEAUnTQzhJoq0C7OAODWEbWunxNpnx+34dHc+aBCyv+NDBUUHWTsOVbcmvLG/EwhYzYTpp5ua/t6WMg==",
       "dependencies": {
-        "color-hash": "^2.0.2"
+        "color-hash": "^2.0.2",
+        "react-virtuoso": "^4.12.2"
       },
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@hookform/resolvers": "^3.2.0",
-        "@perses-dev/components": "^0.53.0",
-        "@perses-dev/core": "^0.53.0-rc.2",
-        "@perses-dev/plugin-system": "^0.53.0",
+        "@perses-dev/components": "^0.54.0-beta.1",
+        "@perses-dev/core": "^0.53.0",
+        "@perses-dev/plugin-system": "^0.54.0-beta.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "echarts": "5.5.0",
@@ -6568,6 +6497,38 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@tanstack/hotkeys": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/hotkeys/-/hotkeys-0.7.1.tgz",
+      "integrity": "sha512-YHVO1z6wnvUCu7bg870Kv5k2D+FIuIOSIcbN0dAmTTsJ3mLMDLwcTVx0qVaq+SZp1B514JJTqGVstvUp85yIpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "^0.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
+      "integrity": "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==",
+      "license": "MIT",
+      "dependencies": {
+        "remove-accents": "0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "4.44.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
@@ -6577,6 +6538,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-hotkeys": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-hotkeys/-/react-hotkeys-0.9.1.tgz",
+      "integrity": "sha512-/qdQUUVkYAHAWRGdFXqFgWpW/S+a6OzkvxWNWKLLDHQODJlO6EPBPa073CglaafBfzig58RK07T09ET+NnZhpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/hotkeys": "0.7.1",
+        "@tanstack/react-store": "^0.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@tanstack/react-query": {
@@ -6607,6 +6589,24 @@
         }
       }
     },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
+      "integrity": "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.9.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/react-table": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
@@ -6625,6 +6625,16 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/table-core": {
@@ -8321,6 +8331,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -8334,6 +8345,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8387,12 +8399,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=6.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -8816,12 +8828,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
@@ -8868,26 +8882,6 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/b4a": {
       "version": "1.6.7",
@@ -9659,18 +9653,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -10230,6 +10212,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -10358,6 +10341,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -10370,6 +10354,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10398,19 +10383,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookies": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
-      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "keygrip": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/copy-webpack-plugin": {
       "version": "14.0.0",
@@ -11438,15 +11410,6 @@
         "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
-    "node_modules/date-format": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
-      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -11512,12 +11475,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
-      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -11635,21 +11592,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11659,6 +11612,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -11842,6 +11796,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -11875,6 +11830,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -12127,6 +12083,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12258,6 +12215,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-latex": {
@@ -13275,6 +13233,7 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/focus-trap": {
@@ -13290,6 +13249,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -13368,6 +13328,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -13407,6 +13368,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13416,6 +13378,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
@@ -14038,6 +14001,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -14292,53 +14256,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/http-assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
-      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
-      "license": "MIT",
-      "dependencies": {
-        "deep-equal": "~1.0.1",
-        "http-errors": "~1.8.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-assert/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-assert/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-assert/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -14350,6 +14267,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -14750,6 +14668,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -17610,6 +17529,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -17650,19 +17570,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/keygrip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "tsscmp": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -17689,89 +17596,6 @@
       "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/koa": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-3.0.3.tgz",
-      "integrity": "sha512-MeuwbCoN1daWS32/Ni5qkzmrOtQO2qrnfdxDHjrm6s4b59yG4nexAJ0pTEFyzjLp0pBVO80CZp0vW8Ze30Ebow==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^1.3.8",
-        "content-disposition": "~0.5.4",
-        "content-type": "^1.0.5",
-        "cookies": "~0.9.1",
-        "delegates": "^1.0.0",
-        "destroy": "^1.2.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "fresh": "~0.5.2",
-        "http-assert": "^1.5.0",
-        "http-errors": "^2.0.0",
-        "koa-compose": "^4.1.0",
-        "mime-types": "^3.0.1",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/koa-compose": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
-      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-      "license": "MIT"
-    },
-    "node_modules/koa/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/koa/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/koa/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/koa/node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/launch-editor": {
       "version": "2.10.0",
@@ -17912,12 +17736,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeepwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-      "integrity": "sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -18163,22 +17981,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/log4js": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
-      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "flatted": "^3.2.7",
-        "rfdc": "^1.3.0",
-        "streamroller": "^3.1.5"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/long-timeout": {
@@ -18475,6 +18277,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -18484,6 +18287,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -19561,6 +19365,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -19870,6 +19675,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -20526,12 +20332,6 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
-    "node_modules/rambda": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/rambda/-/rambda-9.4.2.tgz",
-      "integrity": "sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==",
-      "license": "MIT"
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -21103,6 +20903,12 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -21351,6 +21157,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -21476,6 +21283,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21877,6 +21685,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shallow-clone": {
@@ -22287,6 +22096,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -22314,52 +22124,6 @@
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.13.2"
-      }
-    },
-    "node_modules/streamroller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
-      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
-      "license": "MIT",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/streamroller/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/streamroller/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/streamroller/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/streamx": {
@@ -23342,6 +23106,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -23671,15 +23436,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.x"
-      }
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -24020,6 +23776,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -24261,6 +24018,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -25972,9 +25730,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.63",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.63.tgz",
-      "integrity": "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -82,14 +82,14 @@
     "@patternfly/react-core": "^6.4.1",
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-templates": "^6.4.1",
-    "@perses-dev/components": "^0.53.0",
+    "@perses-dev/components": "0.54.0-beta.1",
     "@perses-dev/core": "0.53.0",
-    "@perses-dev/dashboards": "^0.53.0",
-    "@perses-dev/plugin-system": "^0.53.0",
-    "@perses-dev/scatter-chart-plugin": "^0.10.0",
-    "@perses-dev/tempo-plugin": "^0.57.0",
-    "@perses-dev/trace-table-plugin": "^0.10.0",
-    "@perses-dev/tracing-gantt-chart-plugin": "^0.12.0",
+    "@perses-dev/dashboards": "0.54.0-beta.1",
+    "@perses-dev/plugin-system": "0.54.0-beta.1",
+    "@perses-dev/scatter-chart-plugin": "0.11.0-beta.0",
+    "@perses-dev/tempo-plugin": "0.58.0-beta.0",
+    "@perses-dev/trace-table-plugin": "0.11.0-beta.0",
+    "@perses-dev/tracing-gantt-chart-plugin": "0.13.0-beta.0",
     "copy-webpack-plugin": "^14.0.0",
     "i18next": "^25.10.5",
     "i18next-http-backend": "^3.0.2",
@@ -102,7 +102,6 @@
     "react-router-dom": "^7"
   },
   "overrides": {
-    "@perses-dev/core": "0.53.0",
     "echarts": "^5.6.0"
   }
 }


### PR DESCRIPTION
Bump @perses-dev packages to their latest versions:
- components, dashboards, plugin-system: 0.53.0 → 0.54.0-beta.1
- tempo-plugin: 0.57.0 → 0.58.0-beta.0
- scatter-chart-plugin: 0.10.0 → 0.11.0-beta.0
- trace-table-plugin: 0.10.0 → 0.11.0-beta.0
- tracing-gantt-chart-plugin: 0.12.0 → 0.13.0-beta.0

## Resolves
https://redhat.atlassian.net/browse/TRACING-6213: Search in gantt chart
https://redhat.atlassian.net/browse/COO-1612: Fix resizing attribute pane
https://redhat.atlassian.net/browse/OU-1285: Fix trace table column sizing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Perses-related dependencies to newer, pinned beta versions for core components and plugins.
  * Adjusted version constraints (several packages moved from caret ranges to exact beta releases).
  * Removed a legacy dependency override so the overrides list now contains only the remaining entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->