### PR TITLE
COO-1836: Fix: Open documentation link in a new browser tab

### DIFF
--- a/web/src/pages/TracesPage/TracesPage.tsx
+++ b/web/src/pages/TracesPage/TracesPage.tsx
@@ -173,6 +173,8 @@ function NoTempoInstance() {
                 variant="link"
                 component="a"
                 href={viewInstallationDocsLink}
+                target="_blank"
+                rel="noopener noreferrer"
                 icon={<ExternalLinkAltIcon />}
                 iconPosition="right"
               >


### PR DESCRIPTION
## Summary

- The **View documentation** link in the empty state (shown when no Tempo instance exists) was opening in the same browser tab, navigating the user away from the OpenShift Console.
- Added `target="_blank"` and `rel="noopener noreferrer"` to the link button in `web/src/pages/TracesPage/TracesPage.tsx` so it opens in a new tab.

## Root Cause

The `<Button component="a">` was missing `target="_blank"` and `rel="noopener noreferrer"` attributes.

## Test plan

- [x] Navigate to **Observe → Traces** on a cluster with no Tempo instance configured.
- [x] Click the **View documentation** link in the empty state.
- [x] Confirm the docs page opens in a **new browser tab** and the Console remains open in the original tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External documentation links now open in a new browser tab, preventing accidental navigation away from the application while accessing helpful resources.
  * Enhanced security for external links through implementation of cross-tab protection measures, safeguarding your browsing experience.