### PR TITLE
No-Jira: Fix e2e test failures: Lightspeed context label and TLS profile page load timeout

### DIFF
--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
   },
   fixturesFolder: 'fixtures',
   defaultCommandTimeout: 40000,
+  pageLoadTimeout: 120000,
   retries: {
     runMode: 0,
     openMode: 0,

--- a/tests/e2e/dt-plugin-tests.cy.ts
+++ b/tests/e2e/dt-plugin-tests.cy.ts
@@ -918,7 +918,7 @@ EOF`,
     cy.log('Verify the trace context attachment is present');
     cy.get('.ols-plugin__context-label-text')
       .should('be.visible')
-      .and('have.text', 'frontend: /dispatch');
+      .and('have.text', 'frontend: GET /dispatch');
 
     olsHelpers.submitPrompt();
 


### PR DESCRIPTION
## Summary

- Update Lightspeed OLS context label assertion from `'frontend: /dispatch'` to `'frontend: GET /dispatch'` — the app now includes the HTTP method in the context attachment label shown in the Lightspeed panel.
- Increase `pageLoadTimeout` from the default 60 s to 120 s to handle slow console reloads after TLS profile changes scale down the COO operator; the console bridge backoff can exceed 60 s before the plugin page fires its `load` event.

## Test plan

- [x] Ran full Cypress e2e suite (`dt-plugin-tests.cy.ts`) — 15/15 passing after fixes
- [x] Previously failing tests now pass: `[Capability:AIIntegration][Capability:Lightspeed]` and `[Capability:TLSProfile]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended page load timeout in test configuration to 120 seconds.
  * Updated test assertion to verify HTTP method is included in context label text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->