### PR TITLE
TRACING-6411: Add preview text to Ask Lightspeed button in Gantt chart

### DIFF
--- a/web/locales/en/plugin__distributed-tracing-console-plugin.json
+++ b/web/locales/en/plugin__distributed-tracing-console-plugin.json
@@ -12,7 +12,7 @@
   "Trace": "Trace",
   "Tracing": "Tracing",
   "Trace is too large to be analyzed by OpenShift Lightspeed. Max size is {{max}} MB.": "Trace is too large to be analyzed by OpenShift Lightspeed. Max size is {{max}} MB.",
-  "Ask OpenShift Lightspeed": "Ask OpenShift Lightspeed",
+  "Ask OpenShift Lightspeed (Preview)": "Ask OpenShift Lightspeed (Preview)",
   "Max traces": "Max traces",
   "Not all matching traces are currently visible. Increase the display limit to view more.": "Not all matching traces are currently visible. Increase the display limit to view more.",
   "Hide graph": "Hide graph",

--- a/web/src/pages/TraceDetailPage/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage/TraceDetailPage.tsx
@@ -229,11 +229,11 @@ function LightspeedButton({ useOpenOLS, traceName, traceYaml }: LightspeedButton
   }
 
   return (
-    <Tooltip content={t('Ask OpenShift Lightspeed')}>
+    <Tooltip content={t('Ask OpenShift Lightspeed (Preview)')}>
       <Button
         variant="plain"
         onClick={handleTraceAISummaryClick}
-        aria-label={t('Ask OpenShift Lightspeed')}
+        aria-label={t('Ask OpenShift Lightspeed (Preview)')}
         icon={<MagicIcon />}
       />
     </Tooltip>


### PR DESCRIPTION
Add "Preview" text to "Ask OpenShift Lightspeed" button in Gantt chart.

## Screenshot
<img width="300" src="https://github.com/user-attachments/assets/d2584678-1aa6-4760-878d-01f30837897e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift Lightspeed feature labeling to include "(Preview)" designation across UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->