### PR TITLE
TRACING-6432: Use multi-arch tls-scanner image in tests

### DIFF
--- a/tests/fixtures/chainsaw-tests/cert-rotation/00-install-tls-scanner.yaml
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/00-install-tls-scanner.yaml
@@ -56,7 +56,7 @@ spec:
   serviceAccountName: tls-scanner
   containers:
   - name: tls-scanner
-    image: quay.io/rhn_support_ikanse/tls-scanner@sha256:3f354b5f3f76a62f3e34edea3361ce79b4f010df1633d03f92e89f6a7a6f1f0b
+    image: quay.io/redhat-distributed-tracing-qe/tls-scanner:latest
     command: ["sleep", "infinity"]
     securityContext:
       allowPrivilegeEscalation: false

--- a/tests/fixtures/chainsaw-tests/cert-rotation/00-install-tls-scanner.yaml
+++ b/tests/fixtures/chainsaw-tests/cert-rotation/00-install-tls-scanner.yaml
@@ -56,7 +56,7 @@ spec:
   serviceAccountName: tls-scanner
   containers:
   - name: tls-scanner
-    image: quay.io/redhat-distributed-tracing-qe/tls-scanner:latest
+    image: quay.io/redhat-distributed-tracing-qe/tls-scanner@sha256:97eb0e39012ff6e37f951ae13d952434e8669690552bcfc177c2bdd79aeccd76
     command: ["sleep", "infinity"]
     securityContext:
       allowPrivilegeEscalation: false

--- a/tests/fixtures/chainsaw-tests/tls-profile/00-install-tls-scanner.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile/00-install-tls-scanner.yaml
@@ -54,7 +54,7 @@ spec:
   serviceAccountName: tls-scanner
   containers:
   - name: tls-scanner
-    image: quay.io/redhat-distributed-tracing-qe/tls-scanner:latest
+    image: quay.io/redhat-distributed-tracing-qe/tls-scanner@sha256:97eb0e39012ff6e37f951ae13d952434e8669690552bcfc177c2bdd79aeccd76
     command: ["sleep", "infinity"]
     securityContext:
       privileged: true

--- a/tests/fixtures/chainsaw-tests/tls-profile/00-install-tls-scanner.yaml
+++ b/tests/fixtures/chainsaw-tests/tls-profile/00-install-tls-scanner.yaml
@@ -54,7 +54,7 @@ spec:
   serviceAccountName: tls-scanner
   containers:
   - name: tls-scanner
-    image: quay.io/rhn_support_ikanse/tls-scanner:latest
+    image: quay.io/redhat-distributed-tracing-qe/tls-scanner:latest
     command: ["sleep", "infinity"]
     securityContext:
       privileged: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image references used by TLS scanner test setups to a newer registry location/version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->