### PR TITLE
TRACING-6317: preselect first Tempo instance if exactly one instance is available

### DIFF
--- a/web/src/components/TempoInstanceDropdown.tsx
+++ b/web/src/components/TempoInstanceDropdown.tsx
@@ -71,6 +71,11 @@ export const TempoInstanceDropdown = ({ tempo, setTempo }: TempoInstanceDropdown
     }
   };
 
+  // Preselect the first instance if there is only one instance available.
+  if (!selected && options.length === 1) {
+    onSelect(options[0].value);
+  }
+
   return (
     <ToolbarGroup variant="filter-group">
       <ToolbarItem>


### PR DESCRIPTION
Preselect first Tempo instance if exactly one instance is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tempo instance selection now auto-fills when only one instance is available, making setup faster and reducing the need for manual selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->