### PR TITLE
TRACING-6700: Fix e2e test stability: chainsaw HEREDOC, Span Name filter, TraceLimits reload

### DIFF
--- a/tests/e2e/dt-plugin-tests.cy.ts
+++ b/tests/e2e/dt-plugin-tests.cy.ts
@@ -347,15 +347,14 @@ describe('tracing-uiplugin', () => {
     }
 
     cy.log('Run Lightspeed Chainsaw test to setup OLSConfig and credentials');
+    const valuesContent = `LIGHTSPEED_PROVIDER_URL: ${Cypress.env('LIGHTSPEED_PROVIDER_URL')}\nLIGHTSPEED_PROVIDER_TOKEN: ${Cypress.env('LIGHTSPEED_PROVIDER_TOKEN')}`;
+    cy.exec(`printf '%b' "${valuesContent}" > /tmp/chainsaw-lightspeed-values.yaml`);
     cy.runChainsawTest(
       './fixtures/lightspeed',
       'Lightspeed OLSConfig and credentials setup',
       {
         timeout: 1800000,
-        extraArgs: `--values - <<EOF
-LIGHTSPEED_PROVIDER_URL: ${Cypress.env('LIGHTSPEED_PROVIDER_URL')}
-LIGHTSPEED_PROVIDER_TOKEN: ${Cypress.env('LIGHTSPEED_PROVIDER_TOKEN')}
-EOF`,
+        extraArgs: '--values /tmp/chainsaw-lightspeed-values.yaml',
       },
     );
 
@@ -795,12 +794,11 @@ EOF`,
 
   it('[Capability:UIPlugin][Capability:TraceLimits] Test trace limit functionality', () => {
     cy.log('Navigate to the observe/traces page');
+    cy.reload();
     cy.visit('/observe/traces');
     cy.url().should('include', '/observe/traces');
     cy.dismissWelcomeModal();
-    cy.get('body').should('be.visible');
-    // Wait for the page to fully render
-    cy.wait(3000);
+    cy.get('input[placeholder="Select a Tempo instance"]', { timeout: 30000 }).should('exist');
 
     cy.log('Select TempoStack instance: chainsaw-rbac / simplst');
     cy.pfTypeahead('Select a Tempo instance').click();
@@ -1202,15 +1200,12 @@ EOF`,
       .find('.pf-v6-c-menu-toggle, .pf-v5-c-menu-toggle').first().click();
     cy.pfSelectMenuItem('Span Name').click();
 
-    cy.log('Open Span Name multi-select and verify options appear');
-    cy.pfMenuToggleByLabel('Multi typeahead checkbox').click();
-    cy.get('.pf-v6-c-menu__item input[type="checkbox"], .pf-v5-c-menu__item input[type="checkbox"]', { timeout: 10000 })
-      .should('have.length.greaterThan', 0);
-
-    cy.log('Select the first span name option');
-    cy.get('.pf-v6-c-menu__item input[type="checkbox"], .pf-v5-c-menu__item input[type="checkbox"]')
-      .first()
-      .check();
+    cy.log('Open Span Name typeahead and type a known span name to filter');
+    cy.get('#multi-typeahead-select-checkbox-input', { timeout: 10000 }).should('be.visible').click();
+    cy.get('#multi-typeahead-select-checkbox-input').type('GET /dispatch');
+    cy.get('.pf-v6-c-menu__item, .pf-v5-c-menu__item', { timeout: 10000 })
+      .contains('GET /dispatch')
+      .click();
 
     cy.log('Verify traces are still visible after Span Name filter');
     cy.get('a.MuiLink-root', { timeout: 30000 }).should('be.visible');


### PR DESCRIPTION
## Summary
- **Chainsaw Lightspeed values**: `cy.exec()` does not properly pipe HEREDOC stdin to `chainsaw --values -`, causing the process to hang indefinitely. Write values to a temp file and pass `--values <file>` instead.
- **Span Name attribute filter**: Tempo `searchTagValues` API returns empty for the intrinsic `name` tag, so the dropdown shows "No results found" with no checkboxes. Use the `isCreatable` typeahead feature to type a known span name (`GET /dispatch`) directly.
- **TraceLimits page load**: After the heavy RBAC test (~280s, many navigations), the plugin component does not render on the next `cy.visit()` due to stale browser state. Add `cy.reload()` before visiting and wait for the Tempo instance input with a 30s timeout.

## Test plan
- [x] Run full e2e test suite (15 tests) — 14/15 passed
- [x] TraceLimits: previously failing, now passes consistently
- [x] AttributeFilters: previously failing, now passes consistently
- [x] Lightspeed chainsaw setup: previously hanging indefinitely, now completes in ~5 min
- [x] Lightspeed AI test: flaky due to non-deterministic LLM response (not addressed by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated coverage for trace-limit behavior and span name filtering.
  - Added more reliable validation of Lightspeed Chainsaw configuration handling.
  - Updated end-to-end checks to wait for the interface to be ready before interacting with trace controls, reducing false failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->